### PR TITLE
Avoid string conversion using `bytes::Regex`

### DIFF
--- a/src/source/jfm.rs
+++ b/src/source/jfm.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use regex::Regex;
+use regex::{bytes::Regex as BytesRegex, Regex};
 use reqwest::StatusCode;
 use serde::Deserialize;
 
@@ -7,7 +7,7 @@ use super::{RemoteId, SourceError};
 
 lazy_static! {
     static ref JFM_IDENTIFIER_RE: Regex = Regex::new(r"^[0-9]{2}\.[0-9]{4}\.[0-9]{2}$").unwrap();
-    static ref BIBTEX_LINK_RE: Regex = Regex::new(r"/bibtex/([0-9]{8})\.bib").unwrap();
+    static ref BIBTEX_LINK_RE: BytesRegex = BytesRegex::new(r"/bibtex/([0-9]{8})\.bib").unwrap();
 }
 
 pub fn is_valid_id(id: &str) -> bool {
@@ -31,13 +31,11 @@ pub fn get_canonical(id: &str) -> Result<Option<RemoteId>, SourceError> {
         code => return Err(SourceError::UnexpectedStatusCode(code)),
     };
 
-    let body_str = std::str::from_utf8(&body).map_err(|_| {
-        SourceError::Unexpected(format!("Request to '{url}' returned invalid UTF-8."))
-    })?;
-
     let mut identifiers = Vec::new();
-    for (_, [sub_id]) in BIBTEX_LINK_RE.captures_iter(body_str).map(|c| c.extract()) {
-        identifiers.push(sub_id);
+    for (_, [sub_id]) in BIBTEX_LINK_RE.captures_iter(&body).map(|c| c.extract()) {
+        // SAFETY: since BIBTEX_LINK_RE only matches on ASCII bytes the match is guaranteed to be
+        // valid UTF-8
+        identifiers.push(unsafe { std::str::from_utf8_unchecked(sub_id) });
     }
 
     match &identifiers[..] {


### PR DESCRIPTION
We can save on a UTF-8 conversion by using `bytes::Regex` directly.