### PR TITLE
Various fixes for issues involving citation keys and aliases

### DIFF
--- a/src/cite_search/aux.rs
+++ b/src/cite_search/aux.rs
@@ -34,6 +34,7 @@ mod test {
 \abx@aux@cite{}{a2}
 \abx@aux@cite{} {a3}
 \abx@aux@cite{0}{a4,a5}
+\abx@aux@cite{} {a 6}
         "#;
         let mut vec: Vec<RecordId> = Vec::new();
         get_citekeys(input, &mut vec);
@@ -41,7 +42,7 @@ mod test {
         for s in ["a1", "a2"] {
             assert!(vec.contains(&RecordId::from(s)));
         }
-        for s in ["a3", "a4", "a5"] {
+        for s in ["a3", "a4", "a5", "a 6"] {
             assert!(!vec.contains(&RecordId::from(s)));
         }
     }

--- a/src/cite_search/tex.rs
+++ b/src/cite_search/tex.rs
@@ -2,6 +2,7 @@ use std::{iter::Extend, sync::LazyLock};
 
 use memchr::{memchr, memchr2, memchr3};
 use regex::Regex;
+use serde_bibtex::token::is_entry_key;
 
 use crate::RecordId;
 
@@ -113,7 +114,7 @@ fn parse_cite_contents<T: Extend<RecordId>>(contents: &str, container: &mut T) {
         contents
             .split(',')
             .map(str::trim)
-            .filter(|k| *k != "*" && !k.is_empty())
+            .filter(|k| *k != "*" && is_entry_key(k))
             .map(Into::into),
     );
 }
@@ -180,7 +181,7 @@ mod test {
 
         get_citekeys(contents, &mut container);
 
-        let expected = ["contains space", "ref1", "ref2", "ref3"];
+        let expected = ["ref1", "ref2", "ref3"];
         for (exp, rec) in zip(expected.iter(), container.iter()) {
             assert_eq!(*exp, rec.name());
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,13 @@ pub use self::{
     record_data::{InvalidBytesError, RecordDataError},
 };
 
+/// A trait for errors which have a representation which only depends on the variant, and not on
+/// particular data associated with the error.
+pub trait ShortError {
+    /// Represent an error in short form.
+    fn short_err(&self) -> &'static str;
+}
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("File type '{0}' not supported")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1008,7 +1008,7 @@ fn validate_bibtex_key(key: String, row: &State<RecordRow>) -> Option<EntryKey<S
                         );
                     } else {
                         error!("{}", parse_result.error);
-                        suggest!("Create an alias which does not contain disallowed characters: {{}}(),=\\#%\"");
+                        suggest!("Create an alias which does not contain whitespace or disallowed characters: {{}}(),=\\#%\"");
                     }
                 }
                 Err(error2) => {

--- a/src/record/key.rs
+++ b/src/record/key.rs
@@ -86,13 +86,13 @@ impl FromStr for Alias {
     type Err = AliasConversionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim();
-        if s.is_empty() {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
             Err(AliasConversionError::Empty(s.to_owned()))
         } else {
-            match s.find(':') {
+            match trimmed.find(':') {
                 Some(_) => Err(AliasConversionError::IsRemoteId(s.to_owned())),
-                None => Ok(Self(s.to_owned())),
+                None => Ok(Self(trimmed.to_owned())),
             }
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -218,6 +218,28 @@ fn alias() -> Result<()> {
         "Could not delete alias which does not exist",
     ));
 
+    let mut cmd = s.cmd()?;
+    cmd.args(["alias", "add", "  ", "not_an_alias"]);
+    cmd.assert().failure().stderr(
+        predicate::str::contains("invalid value '  ' for '<ALIAS>'").and(predicate::str::contains(
+            "alias must contain non-whitespace characters",
+        )),
+    );
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["alias", "add", "\n\t", "not_an_alias"]);
+    cmd.assert().failure().stderr(
+        predicate::str::contains("invalid value '\n\t' for '<ALIAS>'").and(
+            predicate::str::contains("alias must contain non-whitespace characters"),
+        ),
+    );
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["alias", "add", "has ws", "not_an_alias"]);
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Cannot create alias for undefined alias",
+    ));
+
     s.close()
 }
 
@@ -295,6 +317,16 @@ fn bibtex_key_validation() -> Result<()> {
         .success()
         .stdout(predicate::str::is_empty())
         .stderr(predicate::str::is_empty());
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["alias", "add", "has ws", "cst1989"]);
+    cmd.assert().success();
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "has ws"]);
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "identifier contains invalid character",
+    ));
 
     s.close()
 }


### PR DESCRIPTION
As discussed offline, there are some shortcomings with the current implementation:

- [x] Valid bibtex keys cannot contain whitespace.
- [x] A commit was dropped from a previous PR which had some fixes for alias checking