### PR TITLE
Improve database consistency checks

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -295,7 +295,7 @@ impl RecordDatabase {
         let mut faults = Vec::new();
 
         validator.record_indexing(&mut faults)?;
-        validator.consistency(&mut faults)?;
+        validator.invalid_citation_keys(&mut faults)?;
         validator.integrity(&mut faults)?;
         validator.binary_data(&mut faults)?;
 

--- a/src/db/validate.rs
+++ b/src/db/validate.rs
@@ -1,89 +1,136 @@
+use std::{fmt, num::NonZero};
+
 use log::debug;
 use rusqlite::{types::ValueRef, Transaction};
 
 use super::{get_row_id, sql};
-use crate::{error::ValidationError, RawRecordData, RecordId, RemoteId};
+use crate::{error::InvalidBytesError, RawRecordData, RecordId, RemoteId};
+
+/// A possible fault that could occurr inside the database.
+#[derive(Debug)]
+pub enum DatabaseFault {
+    /// A row has an invalid canonical id.
+    RowHasInvalidCanonicalId(i64, String),
+    /// A row does not correspond to a row in the `CitationKeys` table.
+    DanglingRecord(i64, String),
+    /// There are `NonZero<usize>` rows in the `CitationKeys` table which point to a `Records` row which does not exist.
+    NullCitationKeys(NonZero<usize>),
+    /// There was an underlying SQLite integrity error.
+    IntegrityError(String),
+    /// A row in the `Records` table contains invalid binary data.
+    InvalidRecordData(i64, String, InvalidBytesError),
+}
+
+impl fmt::Display for DatabaseFault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DatabaseFault::RowHasInvalidCanonicalId(row_id, name) => {
+                write!(
+                    f,
+                    "Record row '{row_id}' contains record id '{name}' which is not a valid canonical id."
+                )
+            }
+            DatabaseFault::DanglingRecord(row_id, name) => {
+                write!(
+                    f,
+                    "Record row '{row_id}' with record id '{name}' does not contain the corresponding entry in the `CitationKeys` table."
+                )
+            }
+            DatabaseFault::NullCitationKeys(count) => {
+                write!(
+                    f,
+                    "There are {count} citation keys which reference records which does not exist in the database."
+                )
+            }
+            DatabaseFault::IntegrityError(err) => write!(f, "Database integrity error: {err}"),
+            DatabaseFault::InvalidRecordData(row_id, name, err) => write!(
+                f,
+                "Record row '{row_id}' with record id '{name}' has invalid binary data: {err}"
+            ),
+        }
+    }
+}
 
 pub struct DatabaseValidator<'conn> {
     pub tx: Transaction<'conn>,
 }
 
 impl<'conn> DatabaseValidator<'conn> {
-    pub fn commit(self) -> Result<(), ValidationError> {
-        Ok(self.tx.commit()?)
+    pub fn into_tx(self) -> Transaction<'conn> {
+        self.tx
     }
 
-    pub fn record_indexing(&self) -> Result<(), ValidationError> {
-        let mut retriever = self.tx.prepare(sql::get_all_record_data())?;
+    /// Check the contents of the `Records` table for the following errors:
+    /// 1. Invalid formats of canonical ids.
+    /// 2. Records which do not correspond to any rows in the `CitationKeys` table.
+    pub fn record_indexing(&self, faults: &mut Vec<DatabaseFault>) -> Result<(), rusqlite::Error> {
+        debug!("Checking record indexing");
+        let mut retriever = self.tx.prepare("SELECT * FROM Records")?;
         let mut rows = retriever.query([])?;
 
-        // rows does not implement Iterator
         while let Some(row) = rows.next()? {
             // first verify that we actually get a proper canonical id
-            let contents: String = row.get("record_id")?;
-            let canonical_id: RemoteId = match RecordId::from(contents.as_ref()).try_into() {
+            let row_id = row.get("key")?;
+            let name: String = row.get("record_id")?;
+            let canonical_id: RemoteId = match RecordId::from(name.as_ref()).try_into() {
                 Ok(remote_id) => remote_id,
                 Err(_) => {
-                    return Err(ValidationError::ConsistencyError(format!(
-                        "Record row contains record id '{contents}' which is not a valid canonical id"
-                    )));
+                    faults.push(DatabaseFault::RowHasInvalidCanonicalId(row_id, name));
+                    continue;
                 }
             };
 
-            // now, check that it is actually valid
+            // then check that the corresponding record is in the `CitationKeys` table
             if get_row_id(&self.tx, &canonical_id)?.is_none() {
-                return Err(ValidationError::DanglingRecord(contents));
+                faults.push(DatabaseFault::DanglingRecord(row_id, name));
             }
         }
         Ok(())
     }
 
-    pub fn consistency(&self) -> Result<(), ValidationError> {
-        let mut errors: Option<String> = None;
-
-        debug!("Checking foreign key constraints");
-        self.tx.pragma_query(None, "foreign_key_check", |row| {
-            let msg: String = row.get(0)?;
-            let error_msg = errors.get_or_insert_with(String::new);
-            error_msg.push_str("\nForeign key constraint error: ");
-            error_msg.push_str(&msg);
-            Ok(())
-        })?;
-
-        debug!("Checking database integrity");
+    /// Check the database for integrity issues.
+    pub fn integrity(&self, faults: &mut Vec<DatabaseFault>) -> Result<(), rusqlite::Error> {
+        debug!("Checking integrity");
         self.tx.pragma_query(None, "integrity_check", |row| {
             if !matches!(row.get_ref(0)?, ValueRef::Text(b"ok")) {
-                let source_table: String = row.get(0)?;
-                let source_row_id: String = row.get(1)?;
-                let target_table: String = row.get(2)?;
-                let target_row_id: String = row.get(3)?;
-
-                let contents = format!("Row '{source_row_id}' in table '{source_table}' has invalid reference to row '{target_row_id}' in '{target_table}'");
-
-                let error_msg = errors.get_or_insert_with(String::new);
-                error_msg.push_str("\nConsistency error: ");
-                error_msg.push_str(&contents);
+                let err: String = row.get(0)?;
+                faults.push(DatabaseFault::IntegrityError(err));
             }
+            Ok(())
+        })
+    }
+
+    /// Check the `CitationKeys` table for foreign key constraint violations.
+    pub fn consistency(&self, faults: &mut Vec<DatabaseFault>) -> Result<(), rusqlite::Error> {
+        debug!("Checking citation key table consistency");
+        let mut num_faults: usize = 0;
+
+        // since `CitationKeys` is a `WITHOUT ROWID` table, `PRAGMA foreign_key_check;` does not
+        // return meaningful information since it cannot provide a rowid for which the foreign key
+        // constraint is violated. As a result, the best way for us to handle this is just to
+        // return the number of violations.
+        self.tx.pragma_query(None, "foreign_key_check", |_| {
+            num_faults += 1;
             Ok(())
         })?;
 
-        if let Some(message) = errors {
-            Err(ValidationError::ConsistencyError(message))
-        } else {
-            Ok(())
+        if let Some(nz) = NonZero::new(num_faults) {
+            faults.push(DatabaseFault::NullCitationKeys(nz));
         }
+
+        Ok(())
     }
 
-    /// Validate binary data inside a transaction.
-    pub fn record_data(&self) -> Result<(), ValidationError> {
-        debug!("Validating binary record data");
+    /// Validate binary data in the `Records` table.
+    pub fn binary_data(&self, faults: &mut Vec<DatabaseFault>) -> Result<(), rusqlite::Error> {
+        debug!("Checking binary data correctness");
         let mut retriever = self.tx.prepare(sql::get_all_record_data())?;
         let mut rows = retriever.query([])?;
 
-        // rows does not implement Iterator
         while let Some(row) = rows.next()? {
             if let Err(err) = RawRecordData::from_byte_repr(row.get("data")?) {
-                return Err(ValidationError::MalformedRecordData(
+                faults.push(DatabaseFault::InvalidRecordData(
+                    row.get("key")?,
                     row.get("record_id")?,
                     err,
                 ));

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 pub use self::{
     bibtex::BibtexDataError,
-    database::{DatabaseError, ValidationError},
+    database::DatabaseError,
     provider::ProviderError,
     record::{AliasConversionError, RecordError, RecordErrorKind},
     record_data::{InvalidBytesError, RecordDataError},

--- a/src/error/database.rs
+++ b/src/error/database.rs
@@ -1,7 +1,5 @@
 use thiserror::Error;
 
-use super::InvalidBytesError;
-
 #[derive(Error, Debug)]
 pub enum DatabaseError {
     #[error("SQLite error: {0}")]
@@ -12,16 +10,4 @@ pub enum DatabaseError {
     TableIncorrectSchema(String, String),
     #[error("Database has invalid schema version: {0}")]
     InvalidSchemaVersion(i64),
-}
-
-#[derive(Error, Debug)]
-pub enum ValidationError {
-    #[error("SQLite error: {0}")]
-    SQLiteError(#[from] rusqlite::Error),
-    #[error("Record with canonical id '{0}' has error in binary format:\n  {1}")]
-    MalformedRecordData(String, InvalidBytesError),
-    #[error("Internal consistency error(s):{0}")]
-    ConsistencyError(String),
-    #[error("Record row '{0}' present in records table but not in citation keys table")]
-    DanglingRecord(String),
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -550,8 +550,10 @@ fn consistency() -> Result<()> {
             "Repairing dangling record by inserting or overwriting existing citation key",
         )
         .and(predicate::str::contains(
-            "Deleting 2 citation keys which do not reference records",
-        )),
+            "Deleting citation keys which do not reference records:",
+        ))
+        .and(predicate::str::contains("zbl:1337.28015"))
+        .and(predicate::str::contains("zbmath:06346461")),
     );
 
     // check that things are fixed


### PR DESCRIPTION
Changes:

- [x] Do not bail on first consistency error; instead, try to find as many as possible.
- [x] Attempt to fix consistency errors when possible.