### PR TITLE
Implement `autobib path`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "assert_cmd"
@@ -170,6 +170,7 @@ dependencies = [
  "clap-verbosity-flag",
  "clap_complete",
  "crossterm",
+ "data-encoding",
  "delegate",
  "edit",
  "etcetera",
@@ -180,13 +181,14 @@ dependencies = [
  "nucleo-picker",
  "predicates",
  "quick-xml",
+ "rapidhash",
  "regex",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_bibtex",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml",
 ]
 
@@ -254,9 +256,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
 dependencies = [
  "shlex",
 ]
@@ -322,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4db298d517d5fa00b2b84bbe044efd3fde43874a41db0d46f91994646a2da4"
+checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
 dependencies = [
  "clap",
 ]
@@ -428,6 +430,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "delegate"
@@ -556,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -806,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http",
@@ -1084,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1141,9 +1149,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -1234,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1349,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -1363,15 +1371,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1409,7 +1417,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -1428,7 +1436,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1436,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1450,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1486,6 +1494,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rapidhash"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d6ba76b70191f99a2c53bb367c118d5064fa33b6aa6a102fa7751b902c7049"
 
 [[package]]
 name = "rayon"
@@ -1547,9 +1561,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3"
 dependencies = [
  "async-compression",
  "base64",
@@ -1587,6 +1601,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1739,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1749,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -1769,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1780,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -1898,9 +1913,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1963,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1978,11 +1993,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.7"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.7",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -1998,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.7"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2019,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2115,6 +2130,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,9 +2183,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicase"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 clap-verbosity-flag = "3.0"
 crossterm = "0.28"
+data-encoding = "2.6"
 delegate = "0.13"
 edit = "0.1"
 etcetera = "0.8"
@@ -28,6 +29,7 @@ memchr = "2.7"
 nonempty = "0.10"
 nucleo-picker = "0.6"
 quick-xml = { version = "0.37", features = ["serialize"] }
+rapidhash = "1.1"
 regex = "1.11"
 reqwest = { version = "0.12", features = ["rustls-tls", "blocking", "gzip"] }
 rusqlite = { version = "0.32", features = ["bundled", "chrono", "functions"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,7 +331,7 @@ enum AliasCommand {
     },
 }
 
-/// Manage aliases.
+/// Utilities to manage database.
 #[derive(Subcommand)]
 enum UtilCommand {
     /// Check database for errors.

--- a/src/main.rs
+++ b/src/main.rs
@@ -817,7 +817,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             citation_key,
             mkdir,
         } => {
-            let target = get_attachment_dir(
+            let mut target = get_attachment_dir(
                 &mut record_db,
                 citation_key,
                 &client,
@@ -829,6 +829,10 @@ fn run_cli(cli: Cli) -> Result<()> {
             if mkdir {
                 create_dir_all(&target)?;
             }
+
+            // This appends a `/` or `\` when printing, as platform appropriate, to be clear to the
+            // user that this is a directory
+            target.push("");
 
             println!("{}", target.display());
         }

--- a/src/path_hash.rs
+++ b/src/path_hash.rs
@@ -41,9 +41,6 @@ impl PathHash for RemoteId {
             unsafe { from_utf8_unchecked(&buffer[2..4]) },
             unsafe { from_utf8_unchecked(&buffer[4..6]) },
             &sub_id_encoded,
-            // This appends a `/` or `\`, as platform appropriate, to be clear that this
-            // is a directory
-            "",
         ]);
     }
 }

--- a/src/path_hash.rs
+++ b/src/path_hash.rs
@@ -1,0 +1,49 @@
+use std::{hash::Hasher, path::PathBuf, str::from_utf8_unchecked};
+
+use data_encoding::BASE32;
+use rapidhash::RapidInlineHasher;
+
+use crate::RemoteId;
+
+/// A type which can be encoded as a platform-friendly path into a buffer.
+pub trait PathHash {
+    /// Extend the provided buffer with a hashed version of the path.
+    fn path_hash(&self, path_buf: &mut PathBuf);
+}
+
+impl PathHash for RemoteId {
+    /// In order to reduce the number of files which are in the same directory, we apply a 30-bit
+    /// header to each path, which is encoded in base32 as `xx/xx/xx`. Then the corresponding path
+    /// is
+    /// ```text
+    /// provider/xx/xx/xx/base32-encoding-of-sub-id/
+    /// ```
+    /// The 30 bit header is formed by converting the u64 output of the [rapidhash] hashing
+    /// algorithm applied to the sub-id into little endian bytes, then taking the four most
+    /// significant bytes (in decreasing order), encoding using BASE32 into 8 ASCII characters,
+    /// and then taking the first 6.
+    ///
+    /// The header `xx/xx/xx` ensures that each directory does not have more than 1024 immediate
+    /// sub-directories.
+    fn path_hash(&self, path_buf: &mut PathBuf) {
+        let sub_id_bytes = self.sub_id().as_bytes();
+        let mut hasher = RapidInlineHasher::default();
+        hasher.write(sub_id_bytes);
+        let sub_id_hash: [u8; 8] = hasher.finish().to_le_bytes();
+
+        let mut buffer = [0; 8];
+        BASE32.encode_mut(&sub_id_hash[..4], &mut buffer);
+        let sub_id_encoded: String = BASE32.encode(sub_id_bytes);
+        path_buf.extend([
+            self.provider(),
+            // SAFETY: BASE32 encoding only returns ASCII bytes
+            unsafe { from_utf8_unchecked(&buffer[0..2]) },
+            unsafe { from_utf8_unchecked(&buffer[2..4]) },
+            unsafe { from_utf8_unchecked(&buffer[4..6]) },
+            &sub_id_encoded,
+            // This appends a `/` or `\`, as platform appropriate, to be clear that this
+            // is a directory
+            "",
+        ]);
+    }
+}

--- a/src/path_hash.rs
+++ b/src/path_hash.rs
@@ -8,7 +8,7 @@ use crate::RemoteId;
 /// A type which can be encoded as a platform-friendly path into a buffer.
 pub trait PathHash {
     /// Extend the provided buffer with a hashed version of the path.
-    fn path_hash(&self, path_buf: &mut PathBuf);
+    fn extend_attachments_path(&self, path_buf: &mut PathBuf);
 }
 
 impl PathHash for RemoteId {
@@ -25,7 +25,7 @@ impl PathHash for RemoteId {
     ///
     /// The header `xx/xx/xx` ensures that each directory does not have more than 1024 immediate
     /// sub-directories.
-    fn path_hash(&self, path_buf: &mut PathBuf) {
+    fn extend_attachments_path(&self, path_buf: &mut PathBuf) {
         let sub_id_bytes = self.sub_id().as_bytes();
         let mut hasher = RapidInlineHasher::default();
         hasher.write(sub_id_bytes);

--- a/src/record/key.rs
+++ b/src/record/key.rs
@@ -15,7 +15,7 @@ pub struct RecordId {
     provider_len: Option<usize>,
 }
 
-/// Either an [`Alias`] or a [`RemoteId]`.
+/// Either an [`Alias`] or a [`RemoteId`].
 pub enum AliasOrRemoteId {
     Alias(Alias),
     RemoteId(RemoteId),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -30,7 +30,7 @@ impl TestState {
             .arg(self.database.as_ref())
             .arg("--config")
             .arg(self.config.as_ref())
-            .arg("--attach-dir")
+            .arg("--attachments-dir")
             .arg(self.attach_dir.as_ref())
             .arg("--no-interactive");
         Ok(cmd)
@@ -622,11 +622,9 @@ fn info() -> Result<()> {
 fn test_attach() -> Result<()> {
     let s = TestState::init()?;
 
-    let source_file = Path::new("tests/resources/path/attachment.txt");
-
     let temp = assert_fs::NamedTempFile::new("attachment.txt")?;
-    temp.write_file(source_file)?;
-    temp.assert(predicate::path::eq_file(source_file));
+    let temp_contents = "test\ncontents";
+    temp.write_str(temp_contents)?;
 
     let attachment_file = s.attachment("zbmath/JX/TT/CT/GA3DGNBWGQ3DC===/attachment.txt");
 
@@ -635,7 +633,7 @@ fn test_attach() -> Result<()> {
     cmd.arg(temp.as_ref());
     cmd.assert().success();
 
-    attachment_file.assert(predicate::path::eq_file(source_file));
+    attachment_file.assert(predicate::eq(temp_contents));
 
     let mut cmd = s.cmd()?;
     cmd.args(["attach", "zbl:1337.28015"]);
@@ -644,7 +642,7 @@ fn test_attach() -> Result<()> {
     cmd.assert().success();
 
     s.attachment("zbmath/JX/TT/CT/GA3DGNBWGQ3DC===/attach2.txt")
-        .assert(predicate::path::eq_file(source_file));
+        .assert(predicate::eq(temp_contents));
 
     let mut cmd = s.cmd()?;
     cmd.args(["attach", "zbl:1337.28015"]);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -609,6 +609,35 @@ fn info() -> Result<()> {
     s.close()
 }
 
+/// Check that `autobib path` always returns the same values.
+#[test]
+fn test_path_platform_consistency() -> Result<()> {
+    let s = TestState::init()?;
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["path", "zbl:1337.28015"]);
+    cmd.assert().success().stdout(predicate::str::ends_with(
+        "attachments/zbmath/JX/TT/CT/GA3DGNBWGQ3DC===/\n",
+    ));
+
+    let mut cmd = s.cmd()?;
+    cmd.args([
+        "alias",
+        "add",
+        "my-alias",
+        "doi:10.1016/0021-8693(89)90256-1",
+    ]);
+    cmd.assert().success();
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["path", "my-alias"]);
+    cmd.assert().success().stdout(predicate::str::ends_with(
+        "attachments/doi/XN/UL/PE/GEYC4MJQGE3C6MBQGIYS2OBWHEZSQOBZFE4TAMRVGYWTC===/\n",
+    ));
+
+    s.close()
+}
+
 #[test]
 fn edit() -> Result<()> {
     let s = TestState::init()?;

--- a/tests/resources/path/attachment.txt
+++ b/tests/resources/path/attachment.txt
@@ -1,2 +1,0 @@
-attachment
-contents

--- a/tests/resources/path/attachment.txt
+++ b/tests/resources/path/attachment.txt
@@ -1,0 +1,2 @@
+attachment
+contents


### PR DESCRIPTION
A place to work on the `autobib path` features.

Checklist:
- [x] Implement basic path logic.
- [x] ~Add commands to insert new files.~
- [x] ~Add commands to list all files.~ I think this should not be implemented here, since there are too many ways to 'list files' (use `find`? `walkdir`? `ls`?) Instead, I think this should be part of `autobib find`, or similar. See #77 
- [x] ~Figure out how to unify the implementation logic (so that the "path" initialization can be handled *before* we start processing the subcommand).~
- [x] ~Implement filesystem locking logic so we do not have race conditions on edit (malicious race conditions notwithstanding, but we should mainly care about the "multiple instances of autobib using the same database" situation).~