### PR TITLE
Implementation of headless options for `autobib edit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "serde_bibtex",
  "serde_json",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -1620,6 +1621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1862,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2302,6 +2346,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bibtex = "0.6.0"
 serde_json = "1.0"
 thiserror = "1.0"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,45 @@
+use std::{fs::read_to_string, io::ErrorKind, path::Path};
+
+use anyhow::{anyhow, Error};
+use log::{debug, info};
+use serde::{Deserialize, Serialize};
+use toml::from_str;
+
+use crate::normalize::Normalization;
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    #[serde(default)]
+    pub on_insert: Normalization,
+}
+
+impl Config {
+    /// Attempt to load the configuration file from the provided path.
+    ///
+    /// If `missing_ok` is true and the file is not found, this returns the default configuration.
+    pub fn load<P: AsRef<Path>>(path: P, missing_ok: bool) -> Result<Self, Error> {
+        match read_to_string(&path) {
+            Ok(st) => {
+                info!(
+                    "Loading configuration at path '{}'",
+                    path.as_ref().display()
+                );
+                let config = from_str(&st)?;
+                debug!("Using configuration:\n{config:?}");
+                Ok(config)
+            }
+            Err(err) => {
+                if missing_ok && err.kind() == ErrorKind::NotFound {
+                    info!(
+                        "Configuration file not found at path '{}'; using default configuration",
+                        path.as_ref().display()
+                    );
+                    Ok(Self::default())
+                } else {
+                    Err(anyhow!("Failed to load configuration file: {err}"))
+                }
+            }
+        }
+    }
+}

--- a/src/db/data.rs
+++ b/src/db/data.rs
@@ -4,7 +4,7 @@
 //!
 //! The data consists of the entry type (e.g. `article`) as well as the field keys and values (e.g. `title =
 //! {Title}`).
-use std::{borrow::Borrow, collections::BTreeMap, iter::Iterator, str::from_utf8};
+use std::{borrow::Borrow, cmp::PartialEq, collections::BTreeMap, iter::Iterator, str::from_utf8};
 
 use delegate::delegate;
 use serde_bibtex::token::is_balanced;
@@ -32,7 +32,7 @@ pub(crate) type ValueHeader = u16;
 pub(crate) type EntryTypeHeader = u8;
 
 /// This trait represents types which encapsulate the data content of a single BibTeX entry.
-pub trait EntryData {
+pub trait EntryData: PartialEq {
     /// Iterate over `(key, value)` pairs in order.
     fn fields(&self) -> impl Iterator<Item = (&str, &str)>;
 
@@ -284,10 +284,10 @@ impl Default for RecordData {
     }
 }
 
-impl<D: EntryData> From<D> for RecordData {
-    fn from(value: D) -> Self {
-        let mut new = Self::new_unchecked(value.entry_type().to_owned());
-        for (key, value) in value.fields() {
+impl<D: EntryData> From<&D> for RecordData {
+    fn from(data: &D) -> Self {
+        let mut new = Self::new_unchecked(data.entry_type().to_owned());
+        for (key, value) in data.fields() {
             new.fields.insert(key.to_owned(), value.to_owned());
         }
         new

--- a/src/db/data.rs
+++ b/src/db/data.rs
@@ -504,7 +504,7 @@ impl EntryData for &RecordData {
 }
 
 impl Normalize for RecordData {
-    fn normalize_eprint<Q: AsRef<str>>(&mut self, keys: std::slice::Iter<'_, Q>) -> bool {
+    fn set_eprint<Q: AsRef<str>>(&mut self, keys: std::slice::Iter<'_, Q>) -> bool {
         for key in keys {
             match self.is_eprint_normalized(key) {
                 EPrintState::Ok => {
@@ -575,7 +575,7 @@ mod tests {
         ] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["zbl", "doi"].iter());
+        let changed = record_data.set_eprint(["zbl", "doi"].iter());
         assert!(changed);
         assert_eq!(record_data.get("eprint"), Some("yyy"));
         assert_eq!(record_data.get("eprinttype"), Some("zbl"));
@@ -590,7 +590,7 @@ mod tests {
         ] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["doi", "zbl"].iter());
+        let changed = record_data.set_eprint(["doi", "zbl"].iter());
         assert!(!changed);
 
         // set new
@@ -598,7 +598,7 @@ mod tests {
         for (k, v) in [("doi", "xxx"), ("zbl", "yyy")] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["zbl", "doi"].iter());
+        let changed = record_data.set_eprint(["zbl", "doi"].iter());
         assert!(changed);
         assert_eq!(record_data.get("eprint"), Some("yyy"));
         assert_eq!(record_data.get("eprinttype"), Some("zbl"));
@@ -608,7 +608,7 @@ mod tests {
         for (k, v) in [("doi", "xxx"), ("eprint", "xxx")] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["zbl", "doi"].iter());
+        let changed = record_data.set_eprint(["zbl", "doi"].iter());
         assert!(changed);
         assert_eq!(record_data.get("eprint"), Some("xxx"));
         assert_eq!(record_data.get("eprinttype"), Some("doi"));
@@ -618,7 +618,7 @@ mod tests {
         for (k, v) in [("doi", "xxx"), ("eprint", "xxx"), ("eprinttype", "doi")] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["zbl", "doi"].iter());
+        let changed = record_data.set_eprint(["zbl", "doi"].iter());
         assert!(!changed);
 
         // set new skip
@@ -626,7 +626,7 @@ mod tests {
         for (k, v) in [("doi", "xxx")] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["zbl", "doi"].iter());
+        let changed = record_data.set_eprint(["zbl", "doi"].iter());
         assert!(changed);
         assert_eq!(record_data.get("eprint"), Some("xxx"));
         assert_eq!(record_data.get("eprinttype"), Some("doi"));
@@ -636,12 +636,12 @@ mod tests {
         for (k, v) in [("zbl", "yyy"), ("eprinttype", "doi")] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["doi"].iter());
+        let changed = record_data.set_eprint(["doi"].iter());
         assert!(!changed);
 
         // no data skip
         let mut record_data = RecordData::try_new("article".into()).unwrap();
-        let changed = record_data.normalize_eprint(["doi"].iter());
+        let changed = record_data.set_eprint(["doi"].iter());
         assert!(!changed);
 
         // no match multi skip
@@ -649,7 +649,7 @@ mod tests {
         for (k, v) in [("zbl", "yyy"), ("eprinttype", "doi")] {
             record_data.check_and_insert(k.into(), v.into()).unwrap();
         }
-        let changed = record_data.normalize_eprint(["doi", "zbmath"].iter());
+        let changed = record_data.set_eprint(["doi", "zbmath"].iter());
         assert!(!changed);
     }
 

--- a/src/db/data.rs
+++ b/src/db/data.rs
@@ -11,7 +11,7 @@ use serde_bibtex::token::is_balanced;
 
 use crate::{
     error::{InvalidBytesError, RecordDataError},
-    normalize::{normalize_whitespace, Normalize},
+    normalize::{normalize_whitespace_str, Normalize},
 };
 
 /// The current version of the binary data format.
@@ -532,7 +532,7 @@ impl Normalize for RecordData {
         let mut updated = false;
 
         for val in self.fields.values_mut() {
-            if let Some(new_val) = normalize_whitespace(val) {
+            if let Some(new_val) = normalize_whitespace_str(val) {
                 updated = true;
                 // SAFETY: the `normalize_whitespace` function always reduces the length of the
                 // input, since it either deletes unused whitespace, or replaces whitespace

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod entry;
 pub mod error;
 mod http;
 mod logger;
+mod normalize;
 pub mod provider;
 mod record;
 pub mod term;
@@ -52,6 +53,7 @@ use self::{
 pub use self::{
     entry::Entry,
     http::HttpClient,
+    normalize::Normalize,
     record::{get_record_row, Alias, AliasOrRemoteId, RecordId, RemoteId},
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,7 +380,7 @@ fn run_cli(cli: Cli) -> Result<()> {
         Command::Alias { alias_command } => match alias_command {
             AliasCommand::Add { alias, target } => {
                 info!("Creating alias '{alias}' for '{target}'");
-                let (_, row) = get_record_row(&mut record_db, target, &client, &config)?
+                let (_, row) = get_record_row(&mut record_db, target, &client, &config.on_insert)?
                     .exists_or_commit_null("Cannot create alias for")?;
                 if !row.add_alias(&alias)? {
                     error!("Alias already exists: '{alias}'");
@@ -458,8 +458,9 @@ fn run_cli(cli: Cli) -> Result<()> {
             }
         }
         Command::Edit { citation_key } => {
-            let (record, row) = get_record_row(&mut record_db, citation_key, &client, &config)?
-                .exists_or_commit_null("Cannot edit")?;
+            let (record, row) =
+                get_record_row(&mut record_db, citation_key, &client, &config.on_insert)?
+                    .exists_or_commit_null("Cannot edit")?;
             edit_record_and_update(&row, record)?;
             row.commit()?;
         }
@@ -986,7 +987,7 @@ fn retrieve_and_validate_single_entry(
     ignore_null: bool,
     config: &Config,
 ) -> Result<Option<(Entry<RawRecordData>, RemoteId)>, error::Error> {
-    match get_record_row(record_db, citation_key, client, config)? {
+    match get_record_row(record_db, citation_key, client, &config.on_insert)? {
         RecordRowResponse::Exists(record, row) => {
             if retrieve_only {
                 row.commit()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ enum Command {
     /// fields against which to search, use the `--fields` option.
     Find {
         /// Fields to search (e.g. author, title).
-        #[clap(short, long, value_delimiter = ',')]
+        #[arg(short, long, value_delimiter = ',')]
         fields: Vec<String>,
     },
     /// Retrieve records given citation keys.

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -43,7 +43,7 @@ pub trait Normalize {
 /// If the input requires normalization, return the new normalized string. Otherwise, the original
 /// input is already normalized. Note that the returned string, if any, necessarily has a shorter
 /// length than the original string.
-pub fn normalize_whitespace(input: &str) -> Option<String> {
+pub fn normalize_whitespace_str(input: &str) -> Option<String> {
     /// Consume from the [`CharIndices`] as long as the input is whitespace, assuming that we
     /// previously saw a whitespace character.
     ///
@@ -149,96 +149,120 @@ mod tests {
     #[test]
     fn test_normalize_whitespace() {
         // check short circuit
-        assert_eq!(normalize_whitespace("a"), None);
-        assert_eq!(normalize_whitespace("a b c"), None);
-        assert_eq!(normalize_whitespace("a bc def gh"), None);
+        assert_eq!(normalize_whitespace_str("a"), None);
+        assert_eq!(normalize_whitespace_str("a b c"), None);
+        assert_eq!(normalize_whitespace_str("a bc def gh"), None);
 
         // check pruning
-        assert_eq!(normalize_whitespace("a b "), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace(" a b"), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace("a  b "), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace("a\tb"), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace("\ta b"), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace("\t a b"), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace(" \n abc b"), Some("abc b".to_owned()));
-        assert_eq!(normalize_whitespace(" \n\tad b"), Some("ad b".to_owned()));
-        assert_eq!(normalize_whitespace("a\t\n\tba"), Some("a ba".to_owned()));
+        assert_eq!(normalize_whitespace_str("a b "), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace_str(" a b"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace_str("a  b "), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace_str("a\tb"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace_str("\ta b"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace_str("\t a b"), Some("a b".to_owned()));
         assert_eq!(
-            normalize_whitespace("aaa\t \n\tb"),
+            normalize_whitespace_str(" \n abc b"),
+            Some("abc b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str(" \n\tad b"),
+            Some("ad b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str("a\t\n\tba"),
+            Some("a ba".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str("aaa\t \n\tb"),
             Some("aaa b".to_owned())
         );
-        assert_eq!(normalize_whitespace("a \t \n\tb"), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace("a \t \n\tb\t"), Some("a b".to_owned()));
-        assert_eq!(normalize_whitespace(" aaa  b "), Some("aaa b".to_owned()));
         assert_eq!(
-            normalize_whitespace("    a    b    "),
+            normalize_whitespace_str("a \t \n\tb"),
             Some("a b".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("   a\t   b \n   "),
+            normalize_whitespace_str("a \t \n\tb\t"),
+            Some("a b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str(" aaa  b "),
+            Some("aaa b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str("    a    b    "),
+            Some("a b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str("   a\t   b \n   "),
             Some("a b".to_owned())
         );
 
         // check escapes
-        assert_eq!(normalize_whitespace("a\\  b"), None);
-        assert_eq!(normalize_whitespace("a\\b"), None);
-        assert_eq!(normalize_whitespace("a\\\\ b"), None);
-        assert_eq!(normalize_whitespace("a\\\\\\ b"), None);
-        assert_eq!(normalize_whitespace("a\\\\\\\\ b"), None);
-        assert_eq!(normalize_whitespace("a\\\\  b"), Some("a\\\\ b".to_owned()));
-        assert_eq!(normalize_whitespace("a\\\\\tb"), Some("a\\\\ b".to_owned()));
-        assert_eq!(normalize_whitespace("\\"), None);
-        assert_eq!(normalize_whitespace("\\ "), None);
+        assert_eq!(normalize_whitespace_str("a\\  b"), None);
+        assert_eq!(normalize_whitespace_str("a\\b"), None);
+        assert_eq!(normalize_whitespace_str("a\\\\ b"), None);
+        assert_eq!(normalize_whitespace_str("a\\\\\\ b"), None);
+        assert_eq!(normalize_whitespace_str("a\\\\\\\\ b"), None);
+        assert_eq!(
+            normalize_whitespace_str("a\\\\  b"),
+            Some("a\\\\ b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace_str("a\\\\\tb"),
+            Some("a\\\\ b".to_owned())
+        );
+        assert_eq!(normalize_whitespace_str("\\"), None);
+        assert_eq!(normalize_whitespace_str("\\ "), None);
 
         // check edge cases
-        assert_eq!(normalize_whitespace(""), None);
-        assert_eq!(normalize_whitespace(" "), Some("".to_owned()));
-        assert_eq!(normalize_whitespace("  "), Some("".to_owned()));
-        assert_eq!(normalize_whitespace("\t"), Some("".to_owned()));
-        assert_eq!(normalize_whitespace("\n"), Some("".to_owned()));
-        assert_eq!(normalize_whitespace(" \t "), Some("".to_owned()));
+        assert_eq!(normalize_whitespace_str(""), None);
+        assert_eq!(normalize_whitespace_str(" "), Some("".to_owned()));
+        assert_eq!(normalize_whitespace_str("  "), Some("".to_owned()));
+        assert_eq!(normalize_whitespace_str("\t"), Some("".to_owned()));
+        assert_eq!(normalize_whitespace_str("\n"), Some("".to_owned()));
+        assert_eq!(normalize_whitespace_str(" \t "), Some("".to_owned()));
 
         // check non-ASCII
-        assert_eq!(normalize_whitespace("🍄"), None);
-        assert_eq!(normalize_whitespace("\\\u{A0} b"), None);
+        assert_eq!(normalize_whitespace_str("🍄"), None);
+        assert_eq!(normalize_whitespace_str("\\\u{A0} b"), None);
         assert_eq!(
-            normalize_whitespace("\\\u{A0} "),
+            normalize_whitespace_str("\\\u{A0} "),
             Some("\\\u{A0}".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("a\u{A0}🍄 c"),
+            normalize_whitespace_str("a\u{A0}🍄 c"),
             Some("a 🍄 c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("a \u{A0}🍄 c"),
+            normalize_whitespace_str("a \u{A0}🍄 c"),
             Some("a 🍄 c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("🍄 \u{A0} b c"),
+            normalize_whitespace_str("🍄 \u{A0} b c"),
             Some("🍄 b c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("🍄\u{A0} b c"),
+            normalize_whitespace_str("🍄\u{A0} b c"),
             Some("🍄 b c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("\u{A0}a b 🍄"),
+            normalize_whitespace_str("\u{A0}a b 🍄"),
             Some("a b 🍄".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("\u{A0} a b c"),
+            normalize_whitespace_str("\u{A0} a b c"),
             Some("a b c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace(" \u{A0}a b c"),
+            normalize_whitespace_str(" \u{A0}a b c"),
             Some("a b c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("a b c\u{A0}"),
+            normalize_whitespace_str("a b c\u{A0}"),
             Some("a b c".to_owned())
         );
         assert_eq!(
-            normalize_whitespace("a 🍄 c \u{A0}"),
+            normalize_whitespace_str("a 🍄 c \u{A0}"),
             Some("a 🍄 c".to_owned())
         );
     }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -1,0 +1,221 @@
+//! Utilities for normalizing BibTeX data
+use std::str::CharIndices;
+
+pub trait Normalize {
+    /// Attempt to set the `eprint` and `eprinttype` fields from a given field.
+    ///
+    /// Note that, if successful, this will overwrite the `eprint` and eprinttype` fields.
+    ///
+    /// `eprint` will be set to the corresponding value, and `eprinttype` will be set to the
+    /// corresponding key. Returns `true` if the eprint was set, and `false` otherwise.
+    fn normalize_eprint<Q: AsRef<str>>(&mut self, keys: std::slice::Iter<'_, Q>) -> bool;
+
+    /// Normalize whitespace by converting all whitespace blocks into a single ASCII SPACE,
+    /// respecting whitespace which is explicitly escaped by `\`.
+    fn normalize_whitespace(&mut self) -> bool;
+}
+
+/// Normalize whitespace by converting all blocks of consecutive whitespace into a single ASCII SPACE,
+/// respecting whitespace which is explicitly escaped by `\`.
+///
+/// If the input requires normalization, return the new normalized string. Otherwise, the original
+/// input is already normalized. Note that the returned string, if any, necessarily has a shorter
+/// length than the original string.
+pub fn normalize_whitespace(input: &str) -> Option<String> {
+    /// Consume from the [`CharIndices`] as long as the input is whitespace. Assumes that we previously
+    /// saw a whitespace character.
+    ///
+    /// The offset is either the index immediately preceding the non-whitespace character, or the end of
+    /// the input. The bool indicates if we terminated with a backslash.
+    #[inline]
+    fn skip_while_ws(chars: &mut CharIndices) -> (usize, bool) {
+        for (offset, ch) in chars.by_ref() {
+            if !ch.is_whitespace() {
+                return (offset, ch == '\\');
+            }
+        }
+        (chars.offset(), false)
+    }
+
+    /// Consume from the [`CharIndices`] as long as the input does not require normalization,
+    /// assuming that we previously saw a non-whitespace character.
+    ///
+    /// When `skip_while_ok` terminates, it returns the maximal valid char boundary up to which
+    /// point the char iterator does not require modification to normalize whitespace.
+    #[inline]
+    fn skip_while_ok(chars: &mut CharIndices, mut saw_backslash: bool) -> usize {
+        let mut has_trailing_space = false;
+
+        let final_offset = loop {
+            if let Some((offset, ch)) = chars.next() {
+                if saw_backslash {
+                    saw_backslash = false;
+                } else {
+                    match ch {
+                        '\\' => {
+                            saw_backslash = true;
+                        }
+                        ' ' => {
+                            if has_trailing_space {
+                                break offset;
+                            } else {
+                                has_trailing_space = true;
+                            }
+                        }
+                        ch if ch.is_whitespace() => {
+                            break offset;
+                        }
+                        _ => has_trailing_space = false,
+                    }
+                }
+            } else {
+                break chars.offset();
+            }
+        };
+
+        if has_trailing_space {
+            // SAFETY: `has_trailing_space = true` only when we previously saw a space, which
+            // means `final_offset >= 1`.
+            unsafe { final_offset.unchecked_sub(1) }
+        } else {
+            final_offset
+        }
+    }
+
+    /// Run a single iteration step: first, take whitespace, and then continue as far as possible.
+    ///
+    /// The returned index pair `(left, right)` is the next contiguous block on which the
+    /// characters do not require normalization.
+    #[inline]
+    fn run_step(chars: &mut CharIndices) -> (usize, usize) {
+        let (left, saw_backslash) = skip_while_ws(chars);
+        let right = skip_while_ok(chars, saw_backslash);
+        (left, right)
+    }
+
+    let mut chars = input.char_indices();
+    let mut output = String::new();
+
+    loop {
+        let (left, right) = run_step(&mut chars);
+
+        // short-circuit termination: no alloc required
+        if left == 0 && right == input.len() {
+            break None;
+        }
+
+        // the `left < right` check is necessary for the edge case of trailing whitespace,
+        // which requires an extra iteration step to consume but does not result in a
+        // non-trivial block to copy.
+        if left < right {
+            if !output.is_empty() {
+                output.push(' ');
+            }
+            output.push_str(&input[left..right]);
+        }
+
+        if chars.offset() == input.len() {
+            break Some(output);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_whitespace() {
+        // check short circuit
+        assert_eq!(normalize_whitespace("a"), None);
+        assert_eq!(normalize_whitespace("a b c"), None);
+        assert_eq!(normalize_whitespace("a bc def gh"), None);
+
+        // check pruning
+        assert_eq!(normalize_whitespace("a b "), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace(" a b"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace("a  b "), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace("a\tb"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace("\ta b"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace("\t a b"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace(" \n abc b"), Some("abc b".to_owned()));
+        assert_eq!(normalize_whitespace(" \n\tad b"), Some("ad b".to_owned()));
+        assert_eq!(normalize_whitespace("a\t\n\tba"), Some("a ba".to_owned()));
+        assert_eq!(
+            normalize_whitespace("aaa\t \n\tb"),
+            Some("aaa b".to_owned())
+        );
+        assert_eq!(normalize_whitespace("a \t \n\tb"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace("a \t \n\tb\t"), Some("a b".to_owned()));
+        assert_eq!(normalize_whitespace(" aaa  b "), Some("aaa b".to_owned()));
+        assert_eq!(
+            normalize_whitespace("    a    b    "),
+            Some("a b".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("   a\t   b \n   "),
+            Some("a b".to_owned())
+        );
+
+        // check escapes
+        assert_eq!(normalize_whitespace("a\\  b"), None);
+        assert_eq!(normalize_whitespace("a\\b"), None);
+        assert_eq!(normalize_whitespace("a\\\\ b"), None);
+        assert_eq!(normalize_whitespace("a\\\\\\ b"), None);
+        assert_eq!(normalize_whitespace("a\\\\\\\\ b"), None);
+        assert_eq!(normalize_whitespace("a\\\\  b"), Some("a\\\\ b".to_owned()));
+        assert_eq!(normalize_whitespace("a\\\\\tb"), Some("a\\\\ b".to_owned()));
+
+        // check edge cases
+        assert_eq!(normalize_whitespace(""), None);
+        assert_eq!(normalize_whitespace(" "), Some("".to_owned()));
+        assert_eq!(normalize_whitespace("  "), Some("".to_owned()));
+        assert_eq!(normalize_whitespace("\t"), Some("".to_owned()));
+        assert_eq!(normalize_whitespace("\n"), Some("".to_owned()));
+        assert_eq!(normalize_whitespace(" \t "), Some("".to_owned()));
+
+        // check non-ASCII
+        assert_eq!(normalize_whitespace("🍄"), None);
+        assert_eq!(normalize_whitespace("\\\u{A0} b"), None);
+        assert_eq!(
+            normalize_whitespace("\\\u{A0} "),
+            Some("\\\u{A0}".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("a\u{A0}🍄 c"),
+            Some("a 🍄 c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("a \u{A0}🍄 c"),
+            Some("a 🍄 c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("🍄 \u{A0} b c"),
+            Some("🍄 b c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("🍄\u{A0} b c"),
+            Some("🍄 b c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("\u{A0}a b 🍄"),
+            Some("a b 🍄".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("\u{A0} a b c"),
+            Some("a b c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace(" \u{A0}a b c"),
+            Some("a b c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("a b c\u{A0}"),
+            Some("a b c".to_owned())
+        );
+        assert_eq!(
+            normalize_whitespace("a 🍄 c \u{A0}"),
+            Some("a 🍄 c".to_owned())
+        );
+    }
+}

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -1,6 +1,17 @@
 //! Utilities for normalizing BibTeX data
 use std::str::CharIndices;
 
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Normalization {
+    #[serde(default)]
+    normalize_whitespace: bool,
+    #[serde(default)]
+    set_eprint: Vec<String>,
+}
+
 pub trait Normalize {
     /// Attempt to set the `eprint` and `eprinttype` fields from a given field.
     ///
@@ -13,6 +24,16 @@ pub trait Normalize {
     /// Normalize whitespace by converting all whitespace blocks into a single ASCII SPACE,
     /// respecting whitespace which is explicitly escaped by `\`.
     fn normalize_whitespace(&mut self) -> bool;
+
+    /// Apply the given normalizations.
+    #[inline]
+    fn normalize(&mut self, nl: &Normalization) {
+        if nl.normalize_whitespace {
+            self.normalize_whitespace();
+        }
+
+        self.normalize_eprint(nl.set_eprint.iter());
+    }
 }
 
 /// Normalize whitespace by converting all blocks of consecutive whitespace into a single ASCII SPACE,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -505,6 +505,39 @@ fn edit() -> Result<()> {
         .failure()
         .stderr(predicate::str::contains("Cannot edit undefined alias"));
 
+    let predicate_file =
+        predicate::path::eq_file(Path::new("tests/resources/edit/stdout_unedited.txt"))
+            .utf8()
+            .unwrap();
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "mr:3224722"]);
+    cmd.assert().success().stdout(predicate_file);
+
+    let mut cmd = s.cmd()?;
+    cmd.args([
+        "edit",
+        "--non-interactive",
+        "--set-eprint=zbl,doi",
+        "mr:3224722",
+    ]);
+    cmd.assert().success();
+
+    let mut cmd = s.cmd()?;
+    cmd.args([
+        "edit",
+        "mr:3224722",
+        "--non-interactive",
+        "--normalize-whitespace",
+    ]);
+    cmd.assert().success();
+
+    let predicate_file = predicate::path::eq_file(Path::new("tests/resources/edit/stdout.txt"))
+        .utf8()
+        .unwrap();
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "mr:3224722"]);
+    cmd.assert().success().stdout(predicate_file);
+
     s.close()
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,25 +2,37 @@ use assert_cmd::prelude::*;
 use assert_fs::fixture::NamedTempFile;
 use predicates::prelude::*;
 
-use std::{path::Path, process::Command};
+use std::{fs, path::Path, process::Command};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 struct TestState {
     database: NamedTempFile,
+    config: NamedTempFile,
 }
 
 impl TestState {
     fn init() -> Result<Self> {
+        let config = NamedTempFile::new("config.toml")?;
+        fs::write(config.as_ref(), "")?;
         Ok(Self {
             database: NamedTempFile::new("records.db")?,
+            config,
         })
     }
 
     fn cmd(&self) -> Result<Command> {
         let mut cmd = Command::cargo_bin("autobib").unwrap();
-        cmd.arg("--database").arg(self.database.as_ref());
+        cmd.arg("--database")
+            .arg(self.database.as_ref())
+            .arg("--config")
+            .arg(self.config.as_ref());
         Ok(cmd)
+    }
+
+    fn set_config<P: AsRef<Path>>(&self, config: P) -> Result<()> {
+        fs::copy(config, self.config.as_ref())?;
+        Ok(())
     }
 
     fn close(self) -> Result<()> {
@@ -635,6 +647,41 @@ fn repeat() -> Result<()> {
     cmd.assert()
         .success()
         .stderr(predicate::str::contains("Multiple keys for "));
+
+    s.close()
+}
+
+#[test]
+fn config() -> Result<()> {
+    let s = TestState::init()?;
+
+    s.set_config(Path::new("tests/resources/config/malformed.toml"))?;
+    let mut cmd = s.cmd()?;
+    cmd.arg("get");
+    cmd.assert().failure();
+
+    s.set_config(Path::new("tests/resources/config/extra.toml"))?;
+    let mut cmd = s.cmd()?;
+    cmd.arg("get");
+    cmd.assert().failure();
+
+    s.close()
+}
+
+/// Check that the `on_insert` methods work as expected.
+#[test]
+fn on_insert() -> Result<()> {
+    let s = TestState::init()?;
+
+    s.set_config(Path::new("tests/resources/on_insert/config.toml"))?;
+
+    let predicate_file =
+        predicate::path::eq_file(Path::new("tests/resources/on_insert/stdout.txt"))
+            .utf8()
+            .unwrap();
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "mr:3224722"]);
+    cmd.assert().success().stdout(predicate_file);
 
     s.close()
 }

--- a/tests/resources/config/extra.toml
+++ b/tests/resources/config/extra.toml
@@ -1,0 +1,3 @@
+[on_insert]
+normalize_whitespace = true
+extra_key = false

--- a/tests/resources/config/malformed.toml
+++ b/tests/resources/config/malformed.toml
@@ -1,0 +1,2 @@
+[on_insert]
+normalize_whitespace = "true"

--- a/tests/resources/edit/stdout.txt
+++ b/tests/resources/edit/stdout.txt
@@ -1,0 +1,12 @@
+@article{mr:3224722,
+  author = {Hochman, Michael},
+  doi = {10.4007/annals.2014.180.2.7},
+  eprint = {10.4007/annals.2014.180.2.7},
+  eprinttype = {doi},
+  journal = {Ann. of Math. (2)},
+  mrnumber = {3224722},
+  pages = {773--822},
+  title = {On self-similar sets with overlaps and inverse theorems for entropy},
+  volume = {180},
+  year = {2014},
+}

--- a/tests/resources/edit/stdout_unedited.txt
+++ b/tests/resources/edit/stdout_unedited.txt
@@ -1,0 +1,11 @@
+@article{mr:3224722,
+  author = {Hochman, Michael},
+  doi = {10.4007/annals.2014.180.2.7},
+  journal = {Ann. of Math. (2)},
+  mrnumber = {3224722},
+  pages = {773--822},
+  title = {On self-similar sets with overlaps and inverse theorems for
+              entropy},
+  volume = {180},
+  year = {2014},
+}

--- a/tests/resources/on_insert/config.toml
+++ b/tests/resources/on_insert/config.toml
@@ -1,0 +1,3 @@
+[on_insert]
+normalize_whitespace = true
+set_eprint = ["zbl", "zbmath", "doi", "arxiv"]

--- a/tests/resources/on_insert/stdout.txt
+++ b/tests/resources/on_insert/stdout.txt
@@ -1,0 +1,12 @@
+@article{mr:3224722,
+  author = {Hochman, Michael},
+  doi = {10.4007/annals.2014.180.2.7},
+  eprint = {10.4007/annals.2014.180.2.7},
+  eprinttype = {doi},
+  journal = {Ann. of Math. (2)},
+  mrnumber = {3224722},
+  pages = {773--822},
+  title = {On self-similar sets with overlaps and inverse theorems for entropy},
+  volume = {180},
+  year = {2014},
+}


### PR DESCRIPTION
When complete, this PR will resolve #90 .

The main new mechanism is that `RecordData` now implements a few methods which 'canonicalize' the record in some way:

- Whitespace normalization: replace any blocks of unescaped whitespace with a single ASCII space.
- Eprint normalization: this is more a feature for myself, but one of the ways that I (ab)use biblatex is to use biblatex eprint rendering hooks to add automatic links to biblatex entries. This change allows setting the `eprint` and `eprinttype` fields from a given biblatex field (e.g. `arxiv = {...}` becomes `eprint = {...}, eprinttype = {arxiv}`).

Certainly we could apply more renormalizations (key renaming, substituting unicode for tex-style escapes, ...?) but these are the ones that I care about the most for the moment.

In order to apply these edits in bulk, but without impacting the 'fast' path, the implementation I decided on was to (1) add a configuration file (I guess defaults to `~/.config/autobib/config.toml`); and (2) apply the modifications based on the `[on_insert]` section of the configuration file whenever a new record is inserted into the database from a remote provider.

You can try it out yourself as follows: first run
```
autobib get mr:3224722
```
and then create the file `~/.config/autobib/config.toml` with the contents
```toml
[on_insert]
normalize_whitespace = true
set_eprint = ["zbl", "zbmath", "doi", "arxiv"]
```
and then delete the record and run `autobib get` again.

Notably, I did not implement this for `local:` records, since local records are manually edited anyway; however, I suppose that it would be reasonable to do this anyway.