### PR TITLE
Fix `autobib update` behaviour for local records

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ autobib local my-entry
 ```
 creates a record under the identifier `local:my-entry`.
 You will be prompted to fill in the record, unless you pass the `--no-edit` flag.
-To modify the record later, use the [`autobib edit` command](#modifying-records).
+To modify the record later, run the above command again or use the [`autobib edit` command](#modifying-records).
 
 It is also possible to create the local record from a BibTeX file:
 ```bash

--- a/src/error/provider.rs
+++ b/src/error/provider.rs
@@ -12,7 +12,7 @@ pub enum ProviderError {
     #[error("Network failure: {0}")]
     NetworkFailure(#[from] reqwest::Error),
     #[error("Unexpected local record '{0}'")]
-    UndefinedLocal(String),
+    UnexpectedLocal(String),
     #[error("Unexpected status code {0}")]
     UnexpectedStatusCode(StatusCode),
     #[error("Unexpected failure: {0}")]

--- a/src/error/provider.rs
+++ b/src/error/provider.rs
@@ -5,15 +5,15 @@ use super::{RecordDataError, RecordError};
 
 #[derive(Error, Debug)]
 pub enum ProviderError {
-    #[error("Reference source returned an identifier: {0}")]
+    #[error("Reference source returned an invalid identifier: '{0}'")]
     InvalidIdFromProvider(String),
-    #[error("Reference source returned a key corresponding to a null record: {0}")]
+    #[error("Reference source returned a key corresponding to a null record: '{0}'")]
     UnexpectedNullRemoteFromProvider(String),
     #[error("Network failure: {0}")]
     NetworkFailure(#[from] reqwest::Error),
-    #[error("Undefined local record: {0}")]
+    #[error("Unexpected local record '{0}'")]
     UndefinedLocal(String),
-    #[error("Unexpected status code: {0}")]
+    #[error("Unexpected status code {0}")]
     UnexpectedStatusCode(StatusCode),
     #[error("Unexpected failure: {0}")]
     Unexpected(String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -414,7 +414,7 @@ fn run_cli(cli: Cli) -> Result<()> {
                                 let prompt = Confirm::new("Delete anyway?", false);
                                 if !prompt.confirm()? {
                                     row.commit()?;
-                                    error!("Aborted deletion of record: {remote_id}");
+                                    error!("Aborted deletion of '{remote_id}'");
                                     continue;
                                 }
                             }
@@ -433,10 +433,10 @@ fn run_cli(cli: Cli) -> Result<()> {
                     }
                     RecordIdState::UnknownRemoteId(remote_id, missing) => {
                         missing.commit()?;
-                        error!("Identifier not in database: {remote_id}");
+                        error!("Identifier not in database: '{remote_id}'");
                     }
                     RecordIdState::UndefinedAlias(alias) => {
-                        error!("Undefined alias: {alias}");
+                        error!("Undefined alias: '{alias}'");
                     }
                     RecordIdState::InvalidRemoteId(err) => error!("{err}"),
                 }
@@ -742,7 +742,7 @@ fn run_cli(cli: Cli) -> Result<()> {
                 suggest!("Use `autobib get` to retrieve record");
             }
             RecordIdState::UndefinedAlias(alias) => {
-                bail!("Undefined alias: '{alias}");
+                bail!("Undefined alias: '{alias}'");
             }
             RecordIdState::InvalidRemoteId(err) => bail!("{err}"),
         },
@@ -983,14 +983,14 @@ fn retrieve_and_validate_single_entry(
         }
         RecordRowResponse::NullRemoteId(remote_id, missing) => {
             if !ignore_null {
-                error!("Null record: {remote_id}");
+                error!("Null record: '{remote_id}'");
             }
             missing.commit()?;
             Ok(None)
         }
         RecordRowResponse::NullAlias(alias) => {
             if !ignore_null {
-                error!("Undefined alias: {alias}");
+                error!("Undefined alias: '{alias}'");
             }
             Ok(None)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -737,9 +737,11 @@ fn run_cli(cli: Cli) -> Result<()> {
                 };
             }
             RecordIdState::UnknownRemoteId(remote_id, missing) => {
-                missing.commit()?;
                 error!("Record corresponding to '{remote_id}' does not exist in database");
-                suggest!("Use `autobib get` to retrieve record");
+                if !remote_id.is_local() {
+                    suggest!("Use `autobib get` to retrieve record");
+                }
+                missing.commit()?;
             }
             RecordIdState::UndefinedAlias(alias) => {
                 bail!("Undefined alias: '{alias}'");

--- a/src/provider/local.rs
+++ b/src/provider/local.rs
@@ -11,5 +11,5 @@ pub fn is_valid_id(id: &str) -> bool {
 pub fn get_record(id: &str, _client: &HttpClient) -> Result<Option<RecordData>, ProviderError> {
     // WARNING: we must return an error here, or the record will get cached locally which will
     // result in strange errors!
-    Err(ProviderError::UndefinedLocal(id.into()))
+    Err(ProviderError::UnexpectedLocal(id.into()))
 }

--- a/src/record/key.rs
+++ b/src/record/key.rs
@@ -190,6 +190,12 @@ impl RemoteId {
         &self.full_id[..self.provider_len]
     }
 
+    /// Check whether the `provider` part of the remote id is `local`.
+    #[inline]
+    pub fn is_local(&self) -> bool {
+        self.provider() == "local"
+    }
+
     /// Get the `sub_id` part of the remote id, after the separator.
     #[inline]
     pub fn sub_id(&self) -> &str {


### PR DESCRIPTION
`autobib update` is not meant to be run on local records, but the current error messages are confusing. For example, if `local:foo` is in the database and `local:bar` isn't, then the current behaviour is the following.
```
$ autobib update local:foo
error: Provider error: Undefined local record: foo
$ autobib update local:bar
error: Record corresponding to 'local:bar' does not exist in database
suggestion: Use `autobib get` to retrieve record
```

Tasks:
- [x] Change the error messages
- [x] Add tests