### PR TITLE
Add release profile to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ assert_cmd = "2.0"
 assert_fs = "1.1"
 predicates = "3.1"
 
+[profile.release]
+lto = true
+
 [lints.clippy]
 redundant_closure_for_method_calls = "warn"
 same_functions_in_if_condition = "warn"


### PR DESCRIPTION
Adds a release profile to `Cargo.toml`. I've added `lto = true`, as suggested for instance [here](https://matklad.github.io/2021/07/09/inline-in-rust.html#Inlining-in-Practice).

It increases release build compile times a decent amount, but the resulting binary is about 30% smaller. We should definitely use benchmarks to actually decide if it also makes things faster!

@wupr Anything else you think should be added here?