### PR TITLE
Add `--non-interactive` global flag

### DIFF
--- a/src/db/state.rs
+++ b/src/db/state.rs
@@ -248,4 +248,19 @@ impl<'conn> RemoteIdState<'conn> {
             }
         })
     }
+
+    /// Extract the [`RecordRow`] if possible, and otherwise return [`None`].
+    pub fn exists(self) -> Option<State<'conn, RecordRow>> {
+        match self {
+            RemoteIdState::Existent(record_row) => Some(record_row),
+            RemoteIdState::Null(null_row) => {
+                drop(null_row);
+                None
+            }
+            RemoteIdState::Unknown(missing) => {
+                drop(missing);
+                None
+            }
+        }
+    }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,10 +1,7 @@
-use crossterm::{
-    style::{StyledContent, Stylize},
-    tty::IsTty,
-};
+use crossterm::style::{StyledContent, Stylize};
 use log::{Level, Log, Metadata, Record};
 use std::{
-    io,
+    io::{self, IsTerminal},
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -15,7 +12,7 @@ pub(crate) fn log_with_style<Y: FnOnce(&'static str) -> StyledContent<&'static s
     header: &'static str,
     args: &std::fmt::Arguments,
 ) {
-    if io::stderr().is_tty() {
+    if io::stderr().is_terminal() {
         eprintln!("{} {args}", style(header));
     } else {
         eprintln!("{header} {args}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ use chrono::{DateTime, Local};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::aot::{generate, Shell};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
-use crossterm::tty::IsTty;
 use etcetera::{choose_app_strategy, AppStrategy, AppStrategyArgs};
 use itertools::Itertools;
 use log::{error, info, warn};
@@ -1065,7 +1064,7 @@ fn output_entries<D: EntryData, P: AsRef<Path>>(
         write_entries(writer, grouped_entries)?;
     } else {
         let stdout = io::stdout();
-        if stdout.is_tty() {
+        if stdout.is_terminal() {
             // do not write an extra newline if interactive
             if !grouped_entries.is_empty() {
                 write_entries(stdout, grouped_entries)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,9 +143,6 @@ enum Command {
         /// Delete without prompting.
         #[arg(short, long)]
         force: bool,
-        /// Also delete null records from the null record cache.
-        #[arg(short, long)]
-        delete_null: bool,
     },
     /// Edit existing records.
     ///
@@ -441,20 +438,15 @@ fn run_cli(cli: Cli) -> Result<()> {
         Command::Delete {
             citation_keys,
             force,
-            delete_null,
         } => {
             let deduplicated = filter_and_deduplicate_by_canonical(
                 citation_keys.into_iter(),
                 &mut record_db,
                 force,
                 |remote_id, null_row| {
-                    if !delete_null {
-                        null_row.commit()?;
-                        error!("Null record found for '{remote_id}'");
-                        suggest!("Use the `--delete-null` option to also delete null records.");
-                    } else {
-                        null_row.delete()?.commit()?;
-                    }
+                    null_row.commit()?;
+                    error!("Null record found for '{remote_id}'");
+                    suggest!("Deletion of null records is currently unsupported but will be added in the future.");
                     Ok(())
                 },
             )?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -508,6 +508,17 @@ fn delete() -> Result<()> {
     ]);
     cmd.assert().success();
 
+    // do not emit error for forced deletion of a record which does not exist
+    let mut cmd = s.cmd()?;
+    cmd.args(["delete", "arxiv:1212.1873"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Identifier not in database"));
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["delete", "--force", "arxiv:1212.1873"]);
+    cmd.assert().success();
+
     s.close()
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -26,7 +26,8 @@ impl TestState {
         cmd.arg("--database")
             .arg(self.database.as_ref())
             .arg("--config")
-            .arg(self.config.as_ref());
+            .arg(self.config.as_ref())
+            .arg("--no-interactive");
         Ok(cmd)
     }
 
@@ -116,7 +117,6 @@ fn local() -> Result<()> {
         "first",
         "--from",
         "tests/resources/local/first.bib",
-        "--no-edit",
     ]);
     cmd.assert().success();
 
@@ -128,7 +128,7 @@ fn local() -> Result<()> {
     cmd.assert().success().stdout(predicate_file);
 
     let mut cmd = s.cmd()?;
-    cmd.args(["local", "first", "--no-edit"]);
+    cmd.args(["local", "first"]);
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
@@ -137,14 +137,13 @@ fn local() -> Result<()> {
         "first",
         "--from",
         "tests/resources/local/first.bib",
-        "--no-edit",
     ]);
     cmd.assert().failure().stderr(predicate::str::contains(
         "Local record 'local:first' already exists",
     ));
 
     let mut cmd = s.cmd()?;
-    cmd.args(["local", "second", "--no-edit"]);
+    cmd.args(["local", "second"]);
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
@@ -156,13 +155,13 @@ fn local() -> Result<()> {
     cmd.assert().success().stdout(predicate_file);
 
     let mut cmd = s.cmd()?;
-    cmd.args(["local", "second", "--rename-from", "first", "--no-edit"]);
+    cmd.args(["local", "second", "--rename-from", "first"]);
     cmd.assert().failure().stderr(predicate::str::contains(
         "Local record 'local:second' already exists",
     ));
 
     let mut cmd = s.cmd()?;
-    cmd.args(["local", "third", "--rename-from", "first", "--no-edit"]);
+    cmd.args(["local", "third", "--rename-from", "first"]);
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
@@ -204,7 +203,6 @@ fn alias() -> Result<()> {
         "first",
         "--from",
         "tests/resources/local/first.bib",
-        "--no-edit",
     ]);
     cmd.assert().success();
 
@@ -217,7 +215,7 @@ fn alias() -> Result<()> {
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
-    cmd.args(["local", "second", "--no-edit"]);
+    cmd.args(["local", "second"]);
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
@@ -393,7 +391,6 @@ fn delete() -> Result<()> {
         "first",
         "--from",
         "tests/resources/local/first.bib",
-        "--no-edit",
     ]);
     cmd.assert().success();
 
@@ -435,7 +432,6 @@ fn list() -> Result<()> {
         "first",
         "--from",
         "tests/resources/local/first.bib",
-        "--no-edit",
     ]);
     cmd.assert().success();
 
@@ -537,21 +533,11 @@ fn edit() -> Result<()> {
     cmd.assert().success().stdout(predicate_file);
 
     let mut cmd = s.cmd()?;
-    cmd.args([
-        "edit",
-        "--non-interactive",
-        "--set-eprint=zbl,doi",
-        "mr:3224722",
-    ]);
+    cmd.args(["edit", "--set-eprint=zbl,doi", "mr:3224722"]);
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
-    cmd.args([
-        "edit",
-        "mr:3224722",
-        "--non-interactive",
-        "--normalize-whitespace",
-    ]);
+    cmd.args(["edit", "mr:3224722", "--normalize-whitespace"]);
     cmd.assert().success();
 
     let predicate_file = predicate::path::eq_file(Path::new("tests/resources/edit/stdout.txt"))
@@ -583,7 +569,7 @@ fn update_local() -> Result<()> {
     let s = TestState::init()?;
 
     let mut cmd = s.cmd()?;
-    cmd.args(["local", "one", "--no-edit"]);
+    cmd.args(["local", "one"]);
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;


### PR DESCRIPTION
This simplifies the argument structure of subcommands.

The new global flag
- replaces the `--non-interactive` flag for `autobib edit`;
- replaces the `--no-edit` flag for `autobib local`;
- implies `--prefer-current` for `autobib update`; and
- implies `--force` for `autobib delete`.

Originally proposed in a [comment](https://github.com/autobib/autobib/pull/121#issuecomment-2494960897) on #121.