### PR TITLE
Migrate to `nucleo-picker` v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "serde",
  "serde_bibtex",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "toml",
 ]
 
@@ -411,6 +411,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "filedescriptor",
  "mio",
  "parking_lot",
  "rustix",
@@ -531,6 +532,17 @@ name = "fastrand"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
 
 [[package]]
 name = "flate2"
@@ -1206,12 +1218,15 @@ dependencies = [
 
 [[package]]
 name = "nucleo-picker"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6c22729ef2959177f172860fa85d6b46f8151721647340a05ea249612c1c6d"
+checksum = "5c424ff8a5b496c87c555e1a50680d5423d72e4c3a4517744513413f00896ccc"
 dependencies = [
  "crossterm",
+ "memchr",
  "nucleo",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1400,7 +1415,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
@@ -1419,7 +1434,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.3",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1960,11 +1975,31 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.3",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2134,6 +2169,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ etcetera = "0.8"
 itertools = "0.13"
 memchr = "2.7"
 nonempty = "0.10"
-nucleo-picker = "0.5"
+nucleo-picker = "0.6.0"
 quick-xml = { version = "0.37", features = ["serialize"] }
 regex = "1.11"
 reqwest = { version = "0.12", features = ["rustls-tls", "blocking", "gzip"] }

--- a/src/db/state/null.rs
+++ b/src/db/state/null.rs
@@ -42,7 +42,7 @@ impl InDatabase for NullRecordRow {
     }
 }
 
-impl<'conn> State<'conn, NullRecordRow> {
+impl State<'_, NullRecordRow> {
     /// Get the time when the null was cached.
     pub fn get_null_attempted(&self) -> Result<DateTime<Local>, rusqlite::Error> {
         debug!("Getting attempted time for null row '{}'.", self.row_id());

--- a/src/db/state/record.rs
+++ b/src/db/state/record.rs
@@ -53,7 +53,7 @@ impl InDatabase for RecordRow {
     }
 }
 
-impl<'conn> State<'conn, RecordRow> {
+impl State<'_, RecordRow> {
     /// Copy the [`RowData`] of a row corresponding to a [`RecordRow`] to the `Changelog` table.
     pub fn save_to_changelog(&self) -> Result<(), rusqlite::Error> {
         debug!("Saving row '{}' to Changelog table", self.row_id());

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -43,7 +43,7 @@ impl<D: EntryData> Entry<D> {
 
 struct RecordDataWrapper<D>(D);
 
-impl<'a, D: EntryData> Serialize for RecordDataWrapper<&'a D> {
+impl<D: EntryData> Serialize for RecordDataWrapper<&'_ D> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
I made quite substantial API changes upstream in [nucleo-picker](https://github.com/autobib/nucleo-picker) over the weekend. (I don't want to look at screen layout computations for a least a month, I wrote almost 1k LOC to implement single-pass multi-line terminal item rendering...)

The upstream rendering is now way better, and the API is more robust / easier to implement.

Anyway I've just made the correct changes to work with the new API but otherwise didn't modify anything else.