### PR TITLE
Implement record merging

### DIFF
--- a/src/db/data.rs
+++ b/src/db/data.rs
@@ -393,8 +393,16 @@ impl RecordData {
         Ok(self.fields.insert(key, value))
     }
 
+    /// Merge data from `other`, overwriting fields that already exist in `self`.
+    pub fn merge_or_overwrite<D: EntryData>(&mut self, other: &D) -> Result<(), RecordDataError> {
+        for (key, value) in other.fields() {
+            self.check_and_insert(key.to_owned(), value.to_owned())?;
+        }
+        Ok(())
+    }
+
     /// Merge data from `other`, ignoring fields that already exist in `self`.
-    pub fn merge_or_skip<D: EntryData>(&mut self, other: D) -> Result<(), RecordDataError> {
+    pub fn merge_or_skip<D: EntryData>(&mut self, other: &D) -> Result<(), RecordDataError> {
         for (key, value) in other.fields() {
             if !self.fields.contains_key(key) {
                 self.check_and_insert(key.to_owned(), value.to_owned())?;
@@ -409,7 +417,7 @@ impl RecordData {
     /// the key, the existing value in `self` corresponding to the key, and the new value.
     pub fn merge_with_callback<D: EntryData, C: FnMut(&str, &str, &str) -> String>(
         &mut self,
-        other: D,
+        other: &D,
         mut resolve_conflict: C,
     ) -> Result<(), RecordDataError> {
         for (key, value) in other.fields() {

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -71,6 +71,8 @@ sql!(get_null_record_key, "Get a null record key");
 
 sql!(delete_citation_key, "Delete a citation key");
 
+sql!(redirect_citation_key, "Redirect a citation key");
+
 sql!(
     set_citation_key_overwrite,
     "Set a citation key, overwriting if one already exists"

--- a/src/db/sql/redirect_citation_key.sql
+++ b/src/db/sql/redirect_citation_key.sql
@@ -1,0 +1,1 @@
+UPDATE CitationKeys SET record_key = ?1 WHERE record_key = ?2

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -934,6 +934,33 @@ fn test_identifier_exceptions() -> Result<()> {
 }
 
 #[test]
+fn test_merge() -> Result<()> {
+    let s = TestState::init()?;
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "zbl:1337.28015", "arxiv:1212.1873", "mr:3224722"]);
+    cmd.assert().success();
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["alias", "add", "a", "arxiv:1212.1873"]);
+    cmd.assert().success();
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["merge", "mr:3224722", "a", "zbl:1337.28015"]);
+    cmd.assert().success();
+
+    let predicate_file = predicate::path::eq_file(Path::new("tests/resources/merge/stdout.txt"))
+        .utf8()
+        .unwrap();
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "zbmath:06346461"]);
+    cmd.assert().success().stdout(predicate_file);
+
+    s.close()
+}
+
+#[test]
 fn test_quiet_returns_error() -> Result<()> {
     let s = TestState::init()?;
 

--- a/tests/resources/merge/stdout.txt
+++ b/tests/resources/merge/stdout.txt
@@ -1,0 +1,16 @@
+@article{zbmath:06346461,
+  arxiv = {1212.1873},
+  author = {Hochman, Michael},
+  doi = {10.4007/annals.2014.180.2.7},
+  journal = {Ann. of Math. (2)},
+  language = {English},
+  month = {12},
+  mrnumber = {3224722},
+  pages = {773--822},
+  title = {On self-similar sets with overlaps and inverse theorems for
+              entropy},
+  volume = {180},
+  year = {2014},
+  zbl = {1337.28015},
+  zbmath = {06346461},
+}


### PR DESCRIPTION
Implements record merging using the same merge logic as `autobib update`.

This defines a new command `autobib merge`. The first argument is the 'merge target', and the remaining arguments are citation keys that should be merged into the provided record. The CLI options are the same as for `autobib update` with the same merge logic.

The provided citation keys should already be in the database (i.e. no automatic retrieval here). The merge logic is essentially to sequentially merge pairs from left to right, with internal de-duplication (i.e. only joins the data for distinct records).