### PR TITLE
Add `--attachments` mode to `autobib find`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.11",
  "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +569,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,26 +712,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1053,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1070,9 +1058,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1101,9 +1089,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1190,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1632,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
  "bitflags",
  "chrono",
@@ -2256,12 +2244,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,16 @@ data-encoding = "2.6"
 delegate = "0.13"
 edit = "0.1"
 etcetera = "0.8"
-itertools = "0.13"
+itertools = "0.14"
 memchr = "2.7"
-nonempty = "0.10"
+nonempty = "0.11"
 nucleo-picker = "0.8"
 quick-xml = { version = "0.37", features = ["serialize"] }
 rapidhash = "1.1"
 regex = "1.11"
 regex-syntax = "0.8"
 reqwest = { version = "0.12", features = ["rustls-tls", "blocking", "gzip"] }
-rusqlite = { version = "0.32", features = ["bundled", "chrono", "functions"] }
+rusqlite = { version = "0.33", features = ["bundled", "chrono", "functions"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bibtex = "0.6.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_bibtex = "0.6.0"
 serde_json = "1.0"
 thiserror = "2.0"
 toml = "0.8"
+walkdir = "2.5"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -285,25 +285,27 @@ pub fn run_cli(cli: Cli) -> Result<()> {
                 fields.iter().map(|f| f.to_lowercase()).collect();
 
             if with_attachment {
-                if let Some(dir_entries) = choose_attachment_path(
+                let mut picker = choose_attachment_path(
                     record_db,
                     fields_to_search,
                     entry_type,
                     get_attachment_root(&data_dir, cli.attachments_dir)?,
                     Path::is_file,
-                )? {
-                    for entry in dir_entries {
-                        println!("{}", entry.path().display());
+                );
+                match picker.pick()? {
+                    Some(data) => {
+                        for entry in data.attachments.iter() {
+                            println!("{}", entry.path().display());
+                        }
                     }
-                } else {
-                    error!("No item selected.");
+
+                    None => error!("No item selected."),
                 }
             } else {
-                // we search all records for the canonical id
-                if let Some(res) = choose_canonical_id(record_db, fields_to_search, entry_type)? {
-                    println!("{res}");
-                } else {
-                    error!("No item selected.");
+                let mut picker = choose_canonical_id(record_db, fields_to_search, entry_type);
+                match picker.pick()? {
+                    Some(row_data) => println!("{}", row_data.canonical),
+                    None => error!("No item selected."),
                 }
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -305,7 +305,7 @@ pub fn run_cli(cli: Cli) -> Result<()> {
                                 // unfortunately the borrow here is unavoidable since `nucleo` does
                                 // not allow passing ownership of the underlying item buffer back
                                 // to the caller when complete.
-                                let mut attachment_picker = choose_attachment(&data.attachments);
+                                let mut attachment_picker = choose_attachment(data);
                                 match attachment_picker.pick()? {
                                     Some(dir_entry) => {
                                         println!("{}", dir_entry.path().display());

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -52,6 +52,22 @@ pub enum InfoReportType {
 }
 
 #[derive(Debug, Copy, Clone)]
+pub enum FindMode {
+    Attachments,
+    CanonicalId,
+}
+
+impl FindMode {
+    pub fn from_flags(attachments: bool, _records: bool) -> Self {
+        if attachments {
+            FindMode::Attachments
+        } else {
+            FindMode::CanonicalId
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
 pub enum UpdateMode {
     PreferCurrent,
     PreferIncoming,
@@ -155,9 +171,12 @@ pub enum Command {
         /// Display entry type for searching.
         #[arg(short, long)]
         entry_type: bool,
-        /// Only list records with at least one attachment.
-        #[arg(short = 'A', long)]
-        with_attachment: bool,
+        /// Search record attachments and print the selected path.
+        #[arg(long, group = "find_mode")]
+        attachments: bool,
+        /// Search records and print the selected canonical identifier.
+        #[arg(long, group = "find_mode")]
+        records: bool,
     },
     /// Retrieve records given citation keys.
     Get {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -149,9 +149,15 @@ pub enum Command {
     /// Open an interactive picker to search for a given citation key. In order to choose the
     /// fields against which to search, use the `--fields` option.
     Find {
-        /// Fields to search (e.g. author, title), delimited by a comma.
+        /// Fields to search (e.g. author, title), delimited by commas.
         #[arg(short, long, value_delimiter = ',', default_value = "author,title")]
         fields: Vec<String>,
+        /// Display entry type for searching.
+        #[arg(short, long)]
+        entry_type: bool,
+        /// Only list records with at least one attachment.
+        #[arg(short = 'A', long)]
+        with_attachment: bool,
     },
     /// Retrieve records given citation keys.
     Get {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -172,7 +172,7 @@ pub enum Command {
         #[arg(short, long)]
         entry_type: bool,
         /// Search record attachments and print the selected path.
-        #[arg(long, group = "find_mode")]
+        #[arg(short, long, group = "find_mode")]
         attachments: bool,
         /// Search records and print the selected canonical identifier.
         #[arg(long, group = "find_mode")]

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -41,8 +41,7 @@ pub fn get_attachment_root(
     })
 }
 
-/// Obtain the attachment directory corresponding to the provided citation key, with automatic
-/// record retrieval.
+/// Get the attachment directory corresponding to the provided citation key.
 pub fn get_attachment_dir(
     canonical: &RemoteId,
     data_dir: &Path,

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -15,15 +15,14 @@ use crate::{
     record::{get_remote_response_recursive, RecursiveRemoteResponse, RemoteId},
 };
 
-/// Obtain the attachment directory corresponding to the provided citation key, with automatic
-/// record retrieval.
-pub fn get_attachment_dir(
-    canonical: &RemoteId,
+/// Get the attachment root directory, either as a default from the data directory or using the
+/// user provided value.
+pub fn get_attachment_root(
     data_dir: &Path,
     default_attachments_dir: Option<PathBuf>,
 ) -> Result<PathBuf, anyhow::Error> {
     // Initialize the file directory path
-    let mut attachments_dir = if let Some(file_dir) = default_attachments_dir {
+    Ok(if let Some(file_dir) = default_attachments_dir {
         // at a user-provided path
         info!(
             "Using user-provided file directory '{}'",
@@ -39,11 +38,19 @@ pub fn get_attachment_dir(
         );
 
         default_attachments_path
-    };
+    })
+}
 
-    canonical.extend_attachments_path(&mut attachments_dir);
-
-    Ok(attachments_dir)
+/// Obtain the attachment directory corresponding to the provided citation key, with automatic
+/// record retrieval.
+pub fn get_attachment_dir(
+    canonical: &RemoteId,
+    data_dir: &Path,
+    default_attachments_dir: Option<PathBuf>,
+) -> Result<PathBuf, anyhow::Error> {
+    let mut attachments_root = get_attachment_root(data_dir, default_attachments_dir)?;
+    canonical.extend_attachments_path(&mut attachments_root);
+    Ok(attachments_root)
 }
 
 /// Either obtain data from a `.bib` file at the provided path, or look up data from the

--- a/src/app/picker.rs
+++ b/src/app/picker.rs
@@ -8,6 +8,7 @@ use crate::{
     path_hash::PathHash,
 };
 
+/// Returns a picker which returns the record attachment data associated with the picked item.
 pub fn choose_attachment_path<F: FnMut(&std::path::Path) -> bool + Send + 'static>(
     mut record_db: RecordDatabase,
     fields_to_search: HashSet<String>,
@@ -54,7 +55,7 @@ pub fn choose_attachment_path<F: FnMut(&std::path::Path) -> bool + Send + 'stati
     picker
 }
 
-/// Open an interactive prompt for the user to select a record.
+/// Returns a picker which returns the record data associated with the picked item.
 pub fn choose_canonical_id(
     mut record_db: RecordDatabase,
     fields_to_search: HashSet<String>,
@@ -74,21 +75,16 @@ pub fn choose_canonical_id(
     picker
 }
 
+/// A wrapper around a [`RowData`] which also contains a list of attachments associated with the
+/// record.
 pub struct AttachmentData {
     pub row_data: RowData,
     pub attachments: Vec<DirEntry>,
 }
 
-impl Render<AttachmentData> for FieldFilterRenderer {
-    type Str<'a> = String;
-
-    fn render<'a>(&self, item: &'a AttachmentData) -> Self::Str<'a> {
-        self.render(&item.row_data)
-    }
-}
-
-/// Given a set of allowed fields renders those fields which are present in the
-/// data in alphabetical order, separated by the `separator`.
+/// Given a set of allowed fields, renders those fields which are present in the
+/// data in alphabetical order, separated by the `separator`. If `entry_type` is `true`, also
+/// render the entry type as a prefix, for example `article: `.
 pub struct FieldFilterRenderer {
     fields_to_search: HashSet<String>,
     separator: &'static str,
@@ -119,5 +115,13 @@ impl Render<RowData> for FieldFilterRenderer {
             output.push_str(val);
         }
         output
+    }
+}
+
+impl Render<AttachmentData> for FieldFilterRenderer {
+    type Str<'a> = String;
+
+    fn render<'a>(&self, item: &'a AttachmentData) -> Self::Str<'a> {
+        self.render(&item.row_data)
     }
 }

--- a/src/app/picker.rs
+++ b/src/app/picker.rs
@@ -1,21 +1,72 @@
-use std::{collections::HashSet, io, thread};
+use std::{collections::HashSet, io, path::PathBuf, thread};
 
 use nucleo_picker::{Picker, Render};
+use walkdir::{DirEntry, WalkDir};
 
 use crate::{
     db::{state::RowData, EntryData, RecordDatabase},
+    path_hash::PathHash,
     record::RemoteId,
 };
+
+pub fn choose_attachment_path<F: FnMut(&std::path::Path) -> bool + Send + 'static>(
+    mut record_db: RecordDatabase,
+    fields_to_search: HashSet<String>,
+    entry_type: bool,
+    attachment_root: PathBuf,
+    mut filter: F,
+) -> Result<Option<Vec<DirEntry>>, io::Error> {
+    // initialize picker
+    let mut picker = Picker::new(FieldFilterRenderer {
+        fields_to_search,
+        separator: " ~ ",
+        entry_type,
+    });
+
+    // populate the picker from a separate thread
+    let injector = picker.injector();
+    thread::spawn(move || {
+        // save some alloctions by reusing the underlying buffer for the temp 'walk dir' root
+        let mut buffer = PathBuf::new();
+
+        record_db.inject_records(injector, |row_data| {
+            // fill the buffer with the attachment path
+            buffer.clone_from(&attachment_root);
+            row_data.canonical.extend_attachments_path(&mut buffer);
+
+            // walk through all of the entries in the attachment path
+            let attachments: Vec<_> = WalkDir::new(&buffer)
+                .into_iter()
+                .flatten()
+                .filter(|dir_entry| filter(dir_entry.path()))
+                .collect();
+
+            if attachments.is_empty() {
+                None
+            } else {
+                Some(AttachmentData {
+                    row_data,
+                    attachments,
+                })
+            }
+        })
+    });
+
+    // get the selection
+    Ok(picker.pick()?.map(|data| data.attachments.clone()))
+}
 
 /// Open an interactive prompt for the user to select a record.
 pub fn choose_canonical_id(
     mut record_db: RecordDatabase,
     fields_to_search: HashSet<String>,
+    entry_type: bool,
 ) -> Result<Option<RemoteId>, io::Error> {
     // initialize picker
     let mut picker = Picker::new(FieldFilterRenderer {
         fields_to_search,
         separator: " ~ ",
+        entry_type,
     });
 
     // populate the picker from a separate thread
@@ -26,19 +77,36 @@ pub fn choose_canonical_id(
     Ok(picker.pick()?.map(|row_data| row_data.canonical.clone()))
 }
 
+struct AttachmentData {
+    row_data: RowData,
+    attachments: Vec<DirEntry>,
+}
+
+impl Render<AttachmentData> for FieldFilterRenderer {
+    type Str<'a> = String;
+
+    fn render<'a>(&self, item: &'a AttachmentData) -> Self::Str<'a> {
+        self.render(&item.row_data)
+    }
+}
+
 /// Given a set of allowed fields renders those fields which are present in the
 /// data in alphabetical order, separated by the `separator`.
 struct FieldFilterRenderer {
     fields_to_search: HashSet<String>,
     separator: &'static str,
+    entry_type: bool,
 }
 
 impl Render<RowData> for FieldFilterRenderer {
     type Str<'a> = String;
 
     fn render<'a>(&self, row_data: &'a RowData) -> Self::Str<'a> {
-        let mut output: String = row_data.data.entry_type().into();
-        output.push_str(": ");
+        let mut output = if self.entry_type {
+            row_data.data.entry_type().to_owned() + ": "
+        } else {
+            String::new()
+        };
 
         let mut first = true;
         for (_, val) in row_data

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -13,6 +13,10 @@ normalize_whitespace = false
 # `eprinttype = {doi}`, overwriting existing values of `eprint` and `eprinttype`.
 set_eprint = []
 
+# Whether or not to strip trailing numbered series indicators, such as the (2) in
+# "Ann. Math. (2)"
+strip_journal_series = false
+
 # Automatically convert aliases to provider:sub_id pairs, based on regex match rules.
 [alias_transform]
 # A list of [pattern, provider] pairs. The first capture group which matches is used

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -11,6 +11,8 @@ pub struct Normalization {
     normalize_whitespace: bool,
     #[serde(default)]
     set_eprint: Vec<String>,
+    #[serde(default)]
+    strip_journal_series: bool,
 }
 
 /// Types which can be normalized by the operations specified in a [`Normalization`].
@@ -30,6 +32,9 @@ pub trait Normalize {
     /// respecting whitespace which is explicitly escaped by `\`.
     fn normalize_whitespace(&mut self) -> bool;
 
+    /// Strip trailing numbered series indicators, such as the (2) in `Ann. Math. (2)`
+    fn strip_journal_series(&mut self) -> bool;
+
     /// Apply the given normalizations.
     #[inline]
     fn normalize(&mut self, nl: &Normalization) {
@@ -38,6 +43,10 @@ pub trait Normalize {
         }
 
         self.set_eprint(nl.set_eprint.iter());
+
+        if nl.strip_journal_series {
+            self.strip_journal_series();
+        }
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1016,6 +1016,25 @@ fn test_normalize() -> Result<()> {
 }
 
 #[test]
+fn test_strip_journal_series() -> Result<()> {
+    let s = TestState::init()?;
+
+    s.set_config(Path::new(
+        "tests/resources/strip_journal_series/config.toml",
+    ))?;
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["get", "zbl:1337.28015"]);
+    cmd.assert().success().stdout(
+        predicate::path::eq_file(Path::new("tests/resources/strip_journal_series/stdout.txt"))
+            .utf8()
+            .unwrap(),
+    );
+
+    s.close()
+}
+
+#[test]
 fn test_auto_alias() -> Result<()> {
     let s = TestState::init()?;
 

--- a/tests/resources/strip_journal_series/config.toml
+++ b/tests/resources/strip_journal_series/config.toml
@@ -1,0 +1,2 @@
+[on_insert]
+strip_journal_series = true

--- a/tests/resources/strip_journal_series/stdout.txt
+++ b/tests/resources/strip_journal_series/stdout.txt
@@ -1,0 +1,12 @@
+@article{zbl:1337.28015,
+  author = {Hochman, Michael},
+  doi = {10.4007/annals.2014.180.2.7},
+  journal = {Ann. Math.},
+  language = {English},
+  pages = {773--822},
+  title = {On self-similar sets with overlaps and inverse theorems for entropy},
+  volume = {180},
+  year = {2014},
+  zbl = {1337.28015},
+  zbmath = {06346461},
+}


### PR DESCRIPTION
This method adds a `--with-attachment` flag to `autobib find` to only list items which actually have at least one attachment.

I also moved the 'entry type' printing under a flag (I think it is a bit more natural to not include it by default).

In the future, once `nucleo_picker` merges the 'multiple columns' (https://github.com/autobib/nucleo-picker/issues/1) feature we can actually add the ability to also match against the attachment name, too. But for now I guess this is the next best thing and works for the use-cases that I care about, at least (e.g. "I want the PDF for that paper").

I modified the printed value upon selection with the `--with-attachment` flag to instead print a (list of) attachment paths, since this felt like the most canonical thing to do. However I do not know if this is a good option overall - should there be a specific 'output type' flag? The only thing was that when I added the output type flag, I realized that basically if you  do not call `--with-attachment`, the 'attachment path' output is quite meaningless (if you just want the 'path root' you can forward to `autobib path` yourself); and if you do call the `--with-attachment` it seems quite rare that you actually care about the canonical ID instead of the attachments.

However I am not totally decided about it so I am curious for thoughts here.