### PR TITLE
Improve autobib edit with new normalizations and allow multiple keys

### DIFF
--- a/docs/changelog/v0.3.0.md
+++ b/docs/changelog/v0.3.0.md
@@ -7,6 +7,7 @@ Changes since `v0.2.0`.
 - Merge duplicate records using `autobib merge`
 - Added normalization methods to transform new records when they are added to the database
   - See the `[on_insert]` section of the example configuration for more detail
+  - Normalizations are also accessible using `autobib edit` to modify existing records
 - Associate files with records using `autobib path` and `autobib attach`
   - Search through attached files using `autobib find --attachments`
 - Added sub-id normalization for simple transformations

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -151,14 +151,17 @@ pub enum Command {
     /// `--set-eprint` accepts a list of field keys, and sets the "eprint" and
     ///   "eprinttype" bibtex fields from the first field key which is present in the record.
     Edit {
-        /// The citation key to edit.
-        citation_key: RecordId,
+        /// The citation key(s) to edit.
+        citation_key: Vec<RecordId>,
         /// Normalize whitespace.
         #[arg(long)]
         normalize_whitespace: bool,
         /// Set "eprint" and "eprinttype" BibTeX fields from provided fields.
         #[arg(long, value_delimiter = ',')]
         set_eprint: Vec<String>,
+        /// Strip trailing journal series
+        #[arg(long)]
+        strip_journal_series: bool,
     },
     /// Search for a citation key.
     ///

--- a/src/db/data.rs
+++ b/src/db/data.rs
@@ -564,6 +564,8 @@ impl Normalize for RecordData {
             if let Some(truncate_offset) =
                 TRAILING_JOURNAL_SERIES_RE.find(journal).map(|m| m.start())
             {
+                // SAFETY: the new value is a prefix of the previous value, and the regex
+                // guarantees that it will not result in unbalanced {}
                 journal.truncate(truncate_offset);
                 return true;
             }


### PR DESCRIPTION
Improves `autobib edit`:

1. Adds the new normalization to `autobib edit` (now with a more robust implementation)
2. Only update the record / changelog if the normalization actually results in a change
3. Allows passing multiple keys, which is particularly useful when applying normalizations in bulk