### PR TITLE
Only allow deletion of null records by age

### DIFF
--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, str::FromStr};
 
 use anyhow::Result;
-use chrono::{DateTime, Local};
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::aot::Shell;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
@@ -424,19 +423,11 @@ pub enum UtilCommand {
     },
     /// Optimize database to (potentially) reduce storage size.
     Optimize,
-    /// Clear caches which match all of the provided conditions.
+    /// Clear all local caches.
     Evict {
-        /// Clear cached items with citation keys matching this regex.
-        ///
-        /// The regex syntax is documented at <https://docs.rs/regex/latest/regex/#syntax>
-        #[arg(short, long)]
-        regex: Option<String>,
-        /// Clear cached items predating the provided time.
-        #[arg(short, long)]
-        before: Option<DateTime<Local>>,
-        /// Clear cached items following the provided time.
-        #[arg(short, long)]
-        after: Option<DateTime<Local>>,
+        /// Clear cached items which are at least `seconds` old.
+        #[arg(long)]
+        max_age: Option<u32>,
     },
     /// List all valid keys.
     List {

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -45,6 +45,13 @@ sql!(get_null_record_data, "Get cached null data");
 
 sql!(set_cached_null, "Set cached null data");
 
+sql!(clear_null_records, "Delete all cached null data");
+
+sql!(
+    clear_null_records_before,
+    "Delete all cached null data before a given datetime"
+);
+
 sql!(get_all_records, "Get all record data");
 
 sql!(get_all_citation_keys, "Get all citation keys");

--- a/src/db/sql/clear_null_records.sql
+++ b/src/db/sql/clear_null_records.sql
@@ -1,0 +1,1 @@
+DELETE FROM NullRecords

--- a/src/db/sql/clear_null_records_before.sql
+++ b/src/db/sql/clear_null_records_before.sql
@@ -1,0 +1,1 @@
+DELETE FROM NullRecords WHERE attempted <= ?1

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1065,7 +1065,13 @@ fn test_cache_evict() -> Result<()> {
     cmd.assert().failure();
 
     let mut cmd = s.cmd()?;
-    cmd.args(["-v", "util", "evict", "--regex", "^zbmath:*"]);
+    cmd.args(["-v", "util", "evict", "--max-age", "10000"]);
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Removed 0 cached null"));
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["-v", "util", "evict"]);
     cmd.assert()
         .success()
         .stderr(predicate::str::contains("Removed 1 cached null"));


### PR DESCRIPTION
Refactor the `autobib util evict` method to only allow deletion of records by age. Moreover, change the argument to be a `max-age` parameter, which is the maximum allowed age (in seconds). This is much more easier than trying to pass a timestamp!