### PR TITLE
New version

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,9 +1,32 @@
 # Architecture
 ## SQLite database format
+The Autobib command-line tool stores data locally in a [SQLite](https://sqlite.org/) database, located (in order of priority)
+
+- at the location specified by the `--database` command line option
+- as set by the `$AUTOBIB_DATABASE_PATH` environment variable
+- by default at `$XDG_CONFIG_HOME/autobib/records.db`
+
+The goal is this section is to give a full, detailed description of the database format.
+
+### Application identifier and database version
+An Autobib database can be identified by the application identifier.
+This is tracked in the SQLite `application_id` field, and can be read with
+```sql
+PRAGMA application_id;
+```
+The application id is hex `16611f2f` or decimal `375463727`.
+This is the `sha256` hash of the string `Autobib`:
+```sh
+echo -n "Autobib" | sha256 | head -c 8
+```
+The database version is tracked in the SQLite `user_version` tag, and can be read with
+```sql
+PRAGMA user_version;
+```
 
 ### `Records` table
 This table has schema
- ```
+ ```sql
  CREATE TABLE Records (
      key INTEGER PRIMARY KEY,
      record_id TEXT NOT NULL UNIQUE,
@@ -14,14 +37,14 @@ This table has schema
  This table stores the record data, and the associated canonical id, as well as the last modified time.
 ### `CitationKeys` table
 This table has schema
-```
+```sql
 CREATE TABLE CitationKeys (
     name TEXT NOT NULL PRIMARY KEY,
     record_key INTEGER,
     CONSTRAINT foreign_record_key
         FOREIGN KEY (record_key)
         REFERENCES Records(key)
-        ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE
 ) STRICT, WITHOUT ROWID;
 ```
 This table stores the keys which are used to lookup records.
@@ -29,27 +52,57 @@ Canonical ids, reference ids, and aliases are all stored in this table.
 
 ### `Changelog` table
 This table has schema
- ```
+ ```sql
  CREATE TABLE Changelog (
      record_id TEXT NOT NULL,
      data BLOB NOT NULL,
      modified TEXT NOT NULL
  ) STRICT;
  ```
- Whenever a row in the `Records` table is modified or deleted, the row is copied into the `Changelog` table as a backup.
+Whenever a row in the `Records` table is modified or deleted, the row is copied into the `Changelog` table as a backup.
 
 ### `NullRecords` table
 This table has schema
-```
+```sql
  CREATE TABLE NullRecords (
      record_id TEXT NOT NULL PRIMARY KEY,
      attempted TEXT NOT NULL
  ) STRICT;
  ```
- This table records the failed lookups if a provided record is invalid.
+This table records the failed lookups if a provided record is invalid.
 
 ## Internal binary data format
-TODO: write
+We use a custom internal binary format to represent the data associated with each bibTex entry.
+
+The data is stored as
+```
+VERSION(u8), DATA(..)
+```
+The first byte is the version.
+Depending on the version, the format of `DATA` is as follows.
+
+### Version 0
+The data is stored as a sequence of blocks.
+```txt
+TYPE, DATA[0], DATA[1], ..
+```
+The `TYPE` consists of
+```txt
+[entry_type_len: u8, entry_type: [u8..]]
+```
+Here, `entry_type_len` is the length of `entry_type`, which has length at most `u8::MAX`.
+Then, each block `DATA` is of the form
+```txt
+[key_len: u8, value_len: u16, key: [u8..], value: [u8..]]
+```
+where `key_len` is the length of the first `key` segment, and the `value_len` is
+the length of the `value` segment. Necessarily, `key` and `value` have lengths at
+most `u8::MAX` and `u16::MAX` respectively.
+
+`value_len` is encoded in little endian format.
+
+The `DATA[i]` are sorted by `key` and each `key` and `entry_type` must be ASCII lowercase. The
+`entry_type` can be any valid UTF-8.
 
 ## Lookup flow
 Given a CLI call of the form

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autobib"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -242,10 +242,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -611,6 +612,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
 name = "flate2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 readme = "README.md"
 keywords = ["cli", "bibtex", "biblatex", "bibliography"]
 categories = ["command-line-utilities"]
-version = "0.2.0"
+version = "0.3.0"
 rust-version = "1.89"
 edition = "2024"
 

--- a/docs/changelog/v0.2.0.md
+++ b/docs/changelog/v0.2.0.md
@@ -1,4 +1,5 @@
 # Version 0.2.0 (2024-11-26)
+Maximum supported database version: `0`
 
 Changes since v0.1.0.
 

--- a/docs/changelog/v0.3.0.md
+++ b/docs/changelog/v0.3.0.md
@@ -1,4 +1,12 @@
 # Version 0.3.0 (2025-09-01)
+This version introduces explicit database versioning.
+The database is automatically migrated to the newest supported version on startup.
+
+To run the migration code, report the database version, and validate your local files on update after updating, run
+```sh
+autobib -v util check
+```
+
 Supported database versions: `<= 1`
 
 Changes since `v0.2.0`.

--- a/docs/changelog/v0.3.0.md
+++ b/docs/changelog/v0.3.0.md
@@ -1,4 +1,5 @@
-# Unreleased
+# Version 0.3.0 (2025-09-01)
+Supported database versions: `<= 1`
 
 Changes since `v0.2.0`.
 
@@ -24,8 +25,16 @@ Changes since `v0.2.0`.
 # Changes to providers
 - Now support `isbn:` and `ol:` (OpenLibrary) providers
 - Fixed spurious failure for some `arxiv:` records
+- Fixed some unnecessary failures with `zbmath:` provider
+- `arxiv:` provider:
+  - now supports explicit version tag
+  - id without version now defaults to most recent arxiv version.
+    In particular, the `date` field is now the date of the most recent version.
+    Use the `origdate` for the date of the first arxiv version.
+  - corrected normalization to squash subject class (if present)
 
 # Fixes
 - Fixed incorrect error code when calling with `-qq`
 - Added interactivity checks throughout with better defaults
 - Fixed some write errors when calling `autobib get` or `autobib out` with `--out` option
+- Improved database schema with automatic migration code

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,12 +55,12 @@ pub use self::cli::{Cli, Command};
 
 /// Run the CLI.
 pub fn run_cli(cli: Cli) -> Result<()> {
-    info!("SQLite version: {}", rusqlite::version());
     info!(
-        "Autobib version: {} (database version: {}), ",
+        "Autobib version: {} (database version: {})",
         env!("CARGO_PKG_VERSION"),
         user_version()
     );
+    info!("SQLite version: {}", rusqlite::version());
 
     let strategy = choose_app_strategy(AppStrategyArgs {
         top_level_domain: "org".to_owned(),
@@ -88,6 +88,7 @@ pub fn run_cli(cli: Cli) -> Result<()> {
         create_dir_all(&data_dir)?;
         RecordDatabase::open(default_db_path)?
     };
+    info!("On-disk database version: {}", record_db.user_version()?);
 
     let (config_path, missing_ok) = cli.config.map_or_else(
         || (strategy.config_dir().join("config.toml"), true),

--- a/src/db.rs
+++ b/src/db.rs
@@ -211,6 +211,11 @@ impl RecordDatabase {
         conn.pragma_query_value(None, "user_version", |row| row.get(0))
     }
 
+    /// Read the user version of the current database.
+    pub fn user_version(&mut self) -> Result<i32, rusqlite::Error> {
+        Self::read_user_version(&mut self.conn)
+    }
+
     /// Read the application id from the database connection.
     fn read_application_id(conn: &mut Connection) -> Result<i32, rusqlite::Error> {
         conn.pragma_query_value(None, "application_id", |row| row.get(0))

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -3,11 +3,11 @@ use rusqlite::Connection;
 use crate::{
     db::{application_id, validate::check_table_schema},
     error::DatabaseError,
-    logger::{debug, info},
+    logger::{debug, warn},
 };
 
 pub fn migrate(conn: &mut Connection, v: i32) -> Result<(), DatabaseError> {
-    info!("Migrating database from v{v} to v{}", v + 1);
+    warn!("Migrating database from v{v} to v{}", v + 1);
     match v {
         0 => {
             // since we did not use the application id in v0, check the table schemas to


### PR DESCRIPTION
This PR cuts a new release `v0.3.0`.

We haven't implemented automated builds / testing on other platforms which was one of my `0.3.0` wish-list items, but at this point I feel a `0.3.0` release is long-awaited so I will advocate cutting one now.

@wupr Can you think of any good reasons to delay?