### PR TITLE
Augment trace logging with detailed error debug printing

### DIFF
--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -8,7 +8,7 @@ use crate::{
     db::state::{RecordRow, State},
     entry::{ConflictResolved, Entry, EntryData, RecordData},
     error::MergeError,
-    logger::{error, info, set_failed, suggest, warn},
+    logger::{error, info, reraise, set_failed, suggest, warn},
     record::Alias,
     term::{Editor, EditorConfig, Input},
 };
@@ -95,7 +95,7 @@ pub fn merge_record_data<'a, D: EntryData + 'a>(
                     let choice = match prompt.input() {
                         Ok(r) => r,
                         Err(error) => {
-                            error!("{error}");
+                            reraise(&error);
                             warn!("Keeping current value for '{key}'");
                             return ConflictResolved::Current;
                         }
@@ -120,7 +120,7 @@ pub fn merge_record_data<'a, D: EntryData + 'a>(
                     match editor.edit(&val) {
                         Ok(new) => ConflictResolved::New(new.unwrap_or(val)),
                         Err(error) => {
-                            error!("{error}");
+                            reraise(&error);
                             warn!("Keeping current value for '{key}'");
                             ConflictResolved::Current
                         }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,11 +3,17 @@ use log::{Level, Log, Metadata, Record};
 #[allow(unused_imports)]
 pub use log::{debug, info, trace, warn};
 use std::{
+    fmt,
     io::{self, IsTerminal},
     sync::atomic::{AtomicBool, Ordering},
 };
 
 static HAS_ERROR: AtomicBool = AtomicBool::new(false);
+
+pub fn reraise<E: fmt::Debug + fmt::Display>(err: &E) {
+    error!("{err}");
+    trace!("{err:?}");
+}
 
 pub(crate) fn log_with_style<Y: FnOnce(&'static str) -> StyledContent<&'static str>>(
     style: Y,
@@ -46,8 +52,7 @@ macro_rules! error {
     };
 }
 
-pub(crate) use error;
-pub(crate) use suggest;
+pub(crate) use {error, suggest};
 
 pub struct Logger {}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use self::{
     app::{Cli, Command, run_cli},
     db::CitationKey,
     entry::RawRecordData,
-    logger::{Logger, error, info},
+    logger::{Logger, info, reraise},
 };
 
 pub use self::{
@@ -62,7 +62,7 @@ fn main() {
 
     // run the cli
     if let Err(err) = run_cli(cli) {
-        error!("{err}");
+        reraise(&err);
     }
 
     // check if there was a non-fatal error during execution


### PR DESCRIPTION
Provides a detailed error debug print for errors which did not originate in the library when run with `trace`-level debugging enabled (i.e. `-vvv`).