### PR TITLE
Remove global option from `--no-interactive`

### DIFF
--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -1,0 +1,17 @@
+# Unreleased
+Supported database versions: `<= 1`
+
+Changes since `v0.3.0`.
+
+## Breaking
+
+- The `--database` flag short form has been changed from `-d` to `-D`.
+- The `--config` flag short form has been changed from `-c` to `-C`.
+  This fixes a conflict with the `--canonical` flag of `autobib util list`.
+
+## New features
+
+- The `-D/--database` and `-C/--config` flags are now global.
+- Adds new `--read-only` flag to disable database/filesystem writes and HTTP requests.
+  - This allows opening database files with potentially incompatible version.
+  - Enables special handling of `autobib get` and `autobib source` to only retrieve records which already exist in the database, without retrieving records from remote.

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -18,10 +18,22 @@ pub struct Cli {
     pub command: Command,
 
     /// Use record database.
-    #[arg(short, long, value_name = "PATH", env = "AUTOBIB_DATABASE_PATH")]
+    #[arg(
+        short = 'D',
+        long,
+        value_name = "PATH",
+        env = "AUTOBIB_DATABASE_PATH",
+        global = true
+    )]
     pub database: Option<PathBuf>,
     /// Use configuration file.
-    #[arg(short, long, value_name = "PATH", env = "AUTOBIB_CONFIG_PATH")]
+    #[arg(
+        short = 'C',
+        long,
+        value_name = "PATH",
+        env = "AUTOBIB_CONFIG_PATH",
+        global = true
+    )]
     pub config: Option<PathBuf>,
     /// Use directory for attachments.
     #[arg(long, value_name = "PATH", env = "AUTOBIB_ATTACHMENTS_DIRECTORY")]


### PR DESCRIPTION
Makes `-I/--no-interactive` non-global, to align with `--config` and `--database`. Is there a reason that this was a global flag before?