### PR TITLE
Release version 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "autobib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 readme = "README.md"
 keywords = ["cli", "bibtex", "biblatex", "bibliography"]
 categories = ["command-line-utilities"]
-version = "0.3.0"
+version = "0.4.0"
 rust-version = "1.90"
 edition = "2024"
 

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -1,17 +1,1 @@
 # Unreleased
-Supported database versions: `<= 1`
-
-Changes since `v0.3.0`.
-
-## Breaking
-
-- The `--database` flag short form has been changed from `-d` to `-D`.
-- The `--config` flag short form has been changed from `-c` to `-C`.
-  This fixes a conflict with the `--canonical` flag of `autobib util list`.
-
-## New features
-
-- The `-D/--database` and `-C/--config` flags are now global.
-- Adds new `--read-only` flag to disable database/filesystem writes and HTTP requests.
-  - This allows opening database files with potentially incompatible version.
-  - Enables special handling of `autobib get` and `autobib source` to only retrieve records which already exist in the database, without retrieving records from remote.

--- a/docs/changelog/v0.4.0.md
+++ b/docs/changelog/v0.4.0.md
@@ -1,0 +1,17 @@
+# Version 0.4.0 (2025-09-22)
+Supported database versions: `<= 1`
+
+Changes since `v0.3.0`.
+
+## Breaking
+
+- The `--database` flag short form has been changed from `-d` to `-D`.
+- The `--config` flag short form has been changed from `-c` to `-C`.
+  This fixes a conflict with the `--canonical` flag of `autobib util list`.
+
+## New features
+
+- The `-D/--database` and `-C/--config` flags are now global.
+- Adds new `--read-only` flag to disable database/filesystem writes and HTTP requests.
+  - This allows opening database files with potentially incompatible version.
+  - Enables special handling of `autobib get` and `autobib source` to only retrieve records which already exist in the database, without retrieving records from remote.


### PR DESCRIPTION
I know we released `0.3.0` quite recently, but with a few breaking changes plus the desire to test that the release workflow works correctly I'm advocating to release `0.4.0` now.