### PR TITLE
Add txt source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Create response cache
       if: steps.response-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: xargs < '${{ env.REMOTES_FILE }}' -- cargo run --locked --features write_response_cache -- -vv get --retrieve-only --ignore-null
+      run: cargo run --locked --features write_response_cache -- -vv source --retrieve-only --ignore-null '${{ env.REMOTES_FILE }}'
 
     # Actually run tests
     - name: Build test binaries

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -1,1 +1,8 @@
 # Unreleased
+Supported database versions: `<= 1`
+
+Changes since `v0.4.0`.
+
+## New features
+
+- Added `.txt` filetype support for `autobib source`, treating each non-empty line as a citation key, and trimming excess whitespace.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,7 +22,7 @@ if [[ ! -f "${AUTOBIB_RESPONSE_CACHE_PATH}" ]]; then
     mkdir -p "${CACHE_DIR}"
 
     # Generate the cache file
-    xargs < "${REMOTES_FILE}" -- cargo run --locked --features write_response_cache -- -vv get --retrieve-only --ignore-null
+    cargo run --locked --features write_response_cache -- -vv source --retrieve-only --ignore-null "${REMOTES_FILE}"
 else
     echo "Cache file found: ${AUTOBIB_RESPONSE_CACHE_PATH}"
 fi

--- a/src/cite_search.rs
+++ b/src/cite_search.rs
@@ -25,6 +25,7 @@
 pub mod bib;
 pub mod tex;
 pub mod tex_auxfile;
+pub mod txt;
 
 use std::{ffi::OsStr, path::Path, str::FromStr};
 
@@ -35,6 +36,8 @@ use crate::{RecordId, error::Error};
 pub enum SourceFileType {
     /// TeX-style contents, such as `.tex` or `.sty` files.
     Tex,
+    /// Text file, with one key per line.
+    Txt,
     /// TeX-based AUX file contents, mainly `.aux` files.
     Aux,
     /// Read citation keys from a BibTeX file.
@@ -47,6 +50,7 @@ impl FromStr for SourceFileType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "tex" | "sty" | "cls" => Ok(Self::Tex),
+            "txt" => Ok(Self::Txt),
             "aux" => Ok(Self::Aux),
             "bib" => Ok(Self::Bib),
             ext => Err(Error::UnsupportedFileType(ext.into())),
@@ -88,6 +92,7 @@ pub fn get_citekeys_filter<T: Extend<RecordId>, F: FnMut(&RecordId) -> bool>(
         SourceFileType::Tex => tex::get_citekeys,
         SourceFileType::Aux => tex_auxfile::get_citekeys,
         SourceFileType::Bib => bib::get_citekeys,
+        SourceFileType::Txt => txt::get_citekeys,
     };
     get_citekey_impl(buffer, &mut FilterExtend { container, f });
 }

--- a/src/cite_search/txt.rs
+++ b/src/cite_search/txt.rs
@@ -1,0 +1,41 @@
+use std::str::from_utf8;
+
+use memchr::memchr_iter;
+
+use crate::RecordId;
+
+pub fn get_citekeys<T: Extend<RecordId>>(buffer: &[u8], container: &mut T) {
+    let mut start = 0;
+    container.extend(memchr_iter(b'\n', buffer).filter_map(|end| {
+        let res = from_utf8(&buffer[start..end])
+            .ok()
+            .and_then(|s| match s.trim() {
+                "" => None,
+                s => Some(RecordId::from(s)),
+            });
+        start = end + 1;
+        res
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_txt_citekeys() {
+        let input = b"
+a
+bc\r
+d e f \t
+
+ghi
+        ";
+        let mut vec: Vec<RecordId> = Vec::new();
+        get_citekeys(input, &mut vec);
+        assert!(vec.len() == 4);
+        for s in ["a", "bc", "d e f", "ghi"] {
+            assert!(vec.contains(&RecordId::from(s)));
+        }
+    }
+}


### PR DESCRIPTION
Adds a `.txt` source by treating each line as the citation key after whitespace trimming and discarding empty lines.

This is sort of the precursor for reading from `stdin`.

Closes #205; the other half has been moved to #208 