### PR TITLE
Add mr normalization with 0-padding

### DIFF
--- a/src/provider/mr.rs
+++ b/src/provider/mr.rs
@@ -14,7 +14,16 @@ struct MathscinetRecord {
 }
 
 pub fn is_valid_id(id: &str) -> ValidationOutcome {
-    (id.len() == 7 && id.as_bytes().iter().all(u8::is_ascii_digit)).into()
+    if id.len() < 6 || id.len() > 7 || !id.as_bytes().iter().all(u8::is_ascii_digit) {
+        return ValidationOutcome::Invalid;
+    }
+
+    if id.len() < 7 {
+        // left pad to length 7 using 0s
+        ValidationOutcome::Normalize(format!("{id:0>7}"))
+    } else {
+        ValidationOutcome::Valid
+    }
 }
 
 pub fn get_record<C: Client>(id: &str, client: &C) -> Result<Option<RecordData>, ProviderError> {

--- a/tests/resources/import/stdout_remote.txt
+++ b/tests/resources/import/stdout_remote.txt
@@ -18,5 +18,6 @@
   title = {Attainable forms of {Assouad} spectra},
   volume = {73},
   year = {2024},
+  zbl = {1562.28062},
   zbmath = {07937992},
 }

--- a/tests/resources/import/stdout_retrieve.txt
+++ b/tests/resources/import/stdout_retrieve.txt
@@ -22,5 +22,6 @@
   title = {Attainable forms of {Assouad} spectra},
   volume = {73},
   year = {2024},
+  zbl = {1562.28062},
   zbmath = {7937992},
 }


### PR DESCRIPTION
Adds 0-padding normalization for mathscinet identifiers (which can sometimes be shorter).