### PR TITLE
Add support for URLs when specifying attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1511,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +1751,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "socks",
  "ureq-proto",
  "utf-8",
  "webpki-roots",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +444,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1017,6 +1055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1124,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -1554,6 +1604,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,12 +1725,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
 dependencies = [
  "base64",
+ "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "ureq-proto",
  "utf-8",
  "webpki-roots",
@@ -1703,6 +1786,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_bibtex = "0.7.0"
 serde_json = "1.0"
 thiserror = "2.0"
 toml = "0.9"
-ureq = { version = "3.1", features = ["json"] }
+ureq = { version = "3.1", features = ["json", "socks-proxy"] }
 walkdir = "2.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_bibtex = "0.7.0"
 serde_json = "1.0"
 thiserror = "2.0"
 toml = "0.9"
-ureq = "3.1"
+ureq = { version = "3.1", features = ["json"] }
 walkdir = "2.5"
 
 [dev-dependencies]

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -1,1 +1,9 @@
 # Unreleased
+
+Supported database versions: `<= 1`
+
+Changes since `v0.4.1`.
+
+## New features
+
+- `autobib attach` now accepts URLs as well as paths for the attachment.

--- a/src/app.rs
+++ b/src/app.rs
@@ -170,7 +170,7 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
             let (record, row) = get_record_row(&mut record_db, citation_key, client, &cfg)?
                 .exists_or_commit_null("Cannot attach file for")?;
             row.commit()?;
-            let mut target = get_attachment_dir(&record.canonical, &data_dir, cli.attachments_dir)?;
+            let mut target = get_attachment_dir(&data_dir, cli.attachments_dir, &record.canonical)?;
 
             let mut opts = OpenOptions::new();
             opts.write(true);
@@ -768,7 +768,7 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
             let (record, row) = get_record_row(&mut record_db, citation_key, client, &cfg)?
                 .exists_or_commit_null("Cannot show directory for")?;
             row.commit()?;
-            let mut target = get_attachment_dir(&record.canonical, &data_dir, cli.attachments_dir)?;
+            let mut target = get_attachment_dir(&data_dir, cli.attachments_dir, &record.canonical)?;
 
             if mkdir {
                 create_dir_all(&target)?;

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -134,20 +134,20 @@ pub enum Command {
         #[command(subcommand)]
         alias_command: AliasCommand,
     },
-    /// Attach files.
+    /// Attach a file.
     ///
-    /// Add new files to the directory associated with a record, as determined by the `path`
+    /// Add a new file to the directory associated with a record, as determined by the `path`
     /// subcommand. The original file is copied to the new directory, or can be renamed
     /// with the `--rename` option.
     Attach {
-        /// The record to associate the files with.
+        /// The record to associate the file with.
         citation_key: RecordId,
-        /// The path to the file to add.
-        file: PathBuf,
+        /// The path or URL for the file to add.
+        file: String,
         /// Rename the file.
         #[arg(short, long)]
         rename: Option<PathBuf>,
-        /// Overwrite existing files with the same name.
+        /// Overwrite an existing file with the same name.
         #[arg(short, long)]
         force: bool,
     },

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -147,7 +147,7 @@ pub enum Command {
         /// Rename the file.
         #[arg(short, long)]
         rename: Option<PathBuf>,
-        /// Overwrite existing files.
+        /// Overwrite existing files with the same name.
         #[arg(short, long)]
         force: bool,
     },

--- a/src/app/path.rs
+++ b/src/app/path.rs
@@ -42,9 +42,9 @@ pub fn get_attachment_root(
 
 /// Get the attachment directory corresponding to the provided citation key.
 pub fn get_attachment_dir(
-    canonical: &RemoteId,
     data_dir: &Path,
     default_attachments_dir: Option<PathBuf>,
+    canonical: &RemoteId,
 ) -> Result<PathBuf, anyhow::Error> {
     let mut attachments_root = get_attachment_root(data_dir, default_attachments_dir)?;
     canonical.extend_attachments_path(&mut attachments_root);

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -41,19 +41,19 @@ strip_journal_series = false
 # 
 # Here are some suggested capture groups for various identifiers.
 # 
-# - arxiv (new style only): ([0-9][0-9](?:0[1-9]|1[0-2])[.][0-9]{4,5})
+# - arxiv (new style only): ([0-9][0-9](?:0[1-9]|1[0-2])[.][0-9]{4,5}(?:v[1-9][0-9]*)?)
 # - doi: (10.\d{4,9}/[-._;()/:a-zA-Z0-9]+)|(10.1002/[^\s]+)
-# - isbn: ([0-9]{10}(?:[0-9]{3})
+# - isbn: ([0-9]{10}(?:[0-9]{3}))
 # - jfm: ([0-9]{2}\.[0-9]{4}\.[0-9]{2})
-# - mr: ([0-9]{7})
+# - mr: ([0-9]{6,7})
 # - ol: ([0-9]{8}M)
 # - zbl: ([0-9]{4}\.[0-9]{5})
-# - zbmath: ([0-9]{8})
+# - zbmath: ([0-9]{7,8})
 #
 # For example, to automatically transform 'zbMATH'-style aliases of the form
 # 'zbMATH06346461', one would set
 #
-# rules = [["^zbMATH([0-9]{8})$", "zbmath"]]
+# rules = [["^zbMATH([0-9]{7,8})$", "zbmath"]]
 rules = []
 
 # Whether or not to automatically create new permanent aliases in the database from

--- a/src/http.rs
+++ b/src/http.rs
@@ -91,7 +91,6 @@ impl UreqClient {
 
         let config = ureq::Agent::config_builder()
             .user_agent(APP_USER_AGENT)
-            .https_only(true)
             .http_status_as_error(false)
             .build();
         let inner = ureq::Agent::new_with_config(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,14 +40,18 @@ static LOGGER: Logger = Logger {};
 
 fn main() {
     std::panic::set_hook(Box::new(|panic_info| {
-        eprintln!("An unexpected error occured while running the program. There are a two possibilities:
-  1. Your database file is malformed or has been edited by another program. Run `autobib util check`
-     to see if this is the case.
-  2. There is a bug in autobib. Please report it at 'https://github.com/autobib/autobib/issues', including
-     the error message below and any other information you can provide about the context in which it occured.
+        eprintln!(
+            "An unexpected error occured while running the program:
+  1. Your database file could be malformed or has been edited by another program.
+     Run `autobib util check` to see if this is the case.
+  2. If you have ruled out 1., this is a bug in autobib. Please report it at
+     > https://github.com/autobib/autobib/issues
+     including the error message below and any other information you can provide
+     about the context in which it occured.
 
 The following is a description of the error which occured:
-");
+"
+        );
         eprintln!("{panic_info}");
     }));
 

--- a/src/provider/isbn.rs
+++ b/src/provider/isbn.rs
@@ -148,15 +148,15 @@ struct OLKeyExtractor {
 pub fn get_canonical<C: Client>(id: &str, client: &C) -> Result<Option<RemoteId>, ProviderError> {
     let response = client.get(format!("https://openlibrary.org/isbn/{id}.json"))?;
 
-    let body = match response.status() {
-        StatusCode::OK => response.into_body().bytes()?,
+    let mut body = match response.status() {
+        StatusCode::OK => response.into_body(),
         StatusCode::NOT_FOUND => {
             return Ok(None);
         }
         code => return Err(ProviderError::UnexpectedStatusCode(code)),
     };
 
-    let extractor: OLKeyExtractor = match serde_json::from_slice(&body) {
+    let extractor: OLKeyExtractor = match body.read_json() {
         Ok(ext) => ext,
         Err(err) => return Err(ProviderError::Unexpected(err.to_string())),
     };

--- a/src/provider/mr.rs
+++ b/src/provider/mr.rs
@@ -31,15 +31,15 @@ pub fn get_record<C: Client>(id: &str, client: &C) -> Result<Option<RecordData>,
         "https://mathscinet.ams.org/mathscinet/api/publications/format?formats=bib&ids={id}"
     ))?;
 
-    let body = match response.status() {
-        StatusCode::OK => response.into_body().bytes()?,
+    let mut body = match response.status() {
+        StatusCode::OK => response.into_body(),
         StatusCode::NOT_FOUND => {
             return Ok(None);
         }
         code => return Err(ProviderError::UnexpectedStatusCode(code)),
     };
 
-    let (msc_record,): (MathscinetRecord,) = match serde_json::from_slice(&body) {
+    let (msc_record,): (MathscinetRecord,) = match body.read_json() {
         Ok(record) => record,
         Err(err) => return Err(ProviderError::Unexpected(err.to_string())),
     };

--- a/src/provider/ol.rs
+++ b/src/provider/ol.rs
@@ -47,7 +47,7 @@ struct OpenLibraryRecord {
 pub fn get_record<C: Client>(id: &str, client: &C) -> Result<Option<RecordData>, ProviderError> {
     let response = client.get(format!("https://openlibrary.org/books/OL{id}.json"))?;
 
-    let body = match response.status() {
+    let mut body = match response.status() {
         StatusCode::OK => response.into_body().bytes()?,
         StatusCode::NOT_FOUND => {
             return Ok(None);
@@ -55,7 +55,7 @@ pub fn get_record<C: Client>(id: &str, client: &C) -> Result<Option<RecordData>,
         code => return Err(ProviderError::UnexpectedStatusCode(code)),
     };
 
-    match serde_json::from_slice(&body) {
+    match body.read_json() {
         Ok(OpenLibraryRecord {
             authors,
             title,


### PR DESCRIPTION
This PR adds support for URLs when using `autobib attach`. Now you can run things like
```
autobib attach arxiv:2309.00092 https://arxiv.org/pdf/2309.00092.pdf
```
In order to distinguish between URLs and paths, I have added a mandatory check for the URI scheme (i.e. `<scheme>://`). Otherwise things like `arxiv.org/pdf/2309.00092.pdf` could equivalently be a URL or a path. I felt this was cleaner than requiring an explicit `--url` flag.

The next step is to allow the URL to be optional, if it can be determined from the identifier.

I can see two ways. First, the fully automatic way:

1. Given a call to `autobib attach <id>`, find all of the remote ids which are equivalent to `<id>`.
2. Iterate over the remote ids, in order of `preferred provider`.
3. The first such provider which supports automatic URLs is the one which creates the URL request.

Second: ask the user to provide the URL mapping as part of configuration, using the same syntax as `[alias_transform]`.

The first solution is nice because it 'just works'. The second solution is nice because (1) it is opt-in only (no funny surprises, just because you forgot an argument); and (2) it allows customization, like providing your own URL maps (or even mapping to a location on your filesystem, like the downloads folder, or something).