### PR TITLE
Run Markdown lints in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
-description: Run Rust tests and checks
+# Run Rust tests and checks
 
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -25,79 +25,94 @@ jobs:
   tests:
     strategy:
       matrix:
-        image: [macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
+        image:
+          [
+            macos-latest,
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            windows-latest,
+            windows-11-arm,
+          ]
     runs-on: ${{ matrix.image }}
     steps:
-    # Windows configuration; this has to run before checkout!
-    - name: Configure Git on Windows
-      if: runner.os == 'Windows'
-      run: git config --global core.autocrlf false
+      # Windows configuration; this has to run before checkout!
+      - name: Configure Git on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
 
-    - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ env.RUST_VERSION }}
-    - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
 
-    # Load/create HTTP response cache
-    - name: Set up response data cache
-      id: response-cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.AUTOBIB_RESPONSE_CACHE_PATH }}
-        key: ${{ env.CACHE_PREFIX }}-${{ matrix.image }}-${{ hashFiles(env.REMOTES_FILE, env.CACHE_FORMAT_DEF) }}
-    - name: Build response cache binary
-      if: steps.response-cache.outputs.cache-hit != 'true'
-      run: cargo build --locked --features write_response_cache
-    - name: Create response cache
-      if: steps.response-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: cargo run --locked --features write_response_cache -- -vv source --retrieve-only --ignore-null '${{ env.REMOTES_FILE }}'
+      # Load/create HTTP response cache
+      - name: Set up response data cache
+        id: response-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.AUTOBIB_RESPONSE_CACHE_PATH }}
+          key: ${{ env.CACHE_PREFIX }}-${{ matrix.image }}-${{ hashFiles(env.REMOTES_FILE, env.CACHE_FORMAT_DEF) }}
+      - name: Build response cache binary
+        if: steps.response-cache.outputs.cache-hit != 'true'
+        run: cargo build --locked --features write_response_cache
+      - name: Create response cache
+        if: steps.response-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: cargo run --locked --features write_response_cache -- -vv source --retrieve-only --ignore-null '${{ env.REMOTES_FILE }}'
 
-    # Actually run tests
-    - name: Build test binaries
-      run: cargo test --no-run --locked --features read_response_cache
-    - name: Run tests
-      run: cargo test --no-fail-fast --locked --features read_response_cache
+      # Actually run tests
+      - name: Build test binaries
+        run: cargo test --no-run --locked --features read_response_cache
+      - name: Run tests
+        run: cargo test --no-fail-fast --locked --features read_response_cache
 
   checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ env.RUST_VERSION }}
-        components: clippy, rustfmt
-    - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
 
-    # Check RUST_VERSION equal to Cargo.toml
-    - name: Check CI rust version equal to Cargo.toml
-      shell: bash
-      run: |
-        CARGO_TOML_RUST_VERSION="$(yq '.package.rust-version' Cargo.toml)"
-        if [[ "$CARGO_TOML_RUST_VERSION" != "${{ env.RUST_VERSION }}" ]]; then
-          echo >&2 "Rust version in Cargo.toml ($CARGO_TOML_RUST_VERSION) not equal to CI: ${{ env.RUST_VERSION }}"
-          echo >&2 "The rust version is set as a repository-level variable"
-          exit 1
-        fi
+      # Check RUST_VERSION equal to Cargo.toml
+      - name: Check CI rust version equal to Cargo.toml
+        shell: bash
+        run: |
+          CARGO_TOML_RUST_VERSION="$(yq '.package.rust-version' Cargo.toml)"
+          if [[ "$CARGO_TOML_RUST_VERSION" != "${{ env.RUST_VERSION }}" ]]; then
+            echo >&2 "Rust version in Cargo.toml ($CARGO_TOML_RUST_VERSION) not equal to CI: ${{ env.RUST_VERSION }}"
+            echo >&2 "The rust version is set as a repository-level variable"
+            exit 1
+          fi
 
-    # Rust doc/fmt/clippy
-    - name: Build docs
-      run: cargo doc --no-deps --locked
-    - name: Run Clippy lints
-      run: cargo clippy --locked
-    - name: Check formatting
-      run: cargo fmt --check
+      # Rust doc/fmt/clippy
+      - name: Build docs
+        run: cargo doc --no-deps --locked
+      - name: Run Clippy lints
+        run: cargo clippy --locked
+      - name: Check formatting
+        run: cargo fmt --check
 
-    # Check remotes file formatting
-    - name: Check remotes file is sorted
-      shell: bash
-      run: sort -C ${{ env.REMOTES_FILE }}
-    - name: Check remotes file contains no duplicates
-      shell: bash
-      run: test "$(cat ${{ env.REMOTES_FILE }} | uniq -d | wc -w)" -eq 0
+      # Markdown lints
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: |
+            **/*.md
+            !target/**/*.md
 
-    # Check bash scripts
-    - name: Checking contents of `scripts` directory
-      shell: bash
-      run: shellcheck scripts/*.sh --enable=all
+      # Check remotes file formatting
+      - name: Check remotes file is sorted
+        shell: bash
+        run: sort -C ${{ env.REMOTES_FILE }}
+      - name: Check remotes file contains no duplicates
+        shell: bash
+        run: test "$(cat ${{ env.REMOTES_FILE }} | uniq -d | wc -w)" -eq 0
+
+      # Check bash scripts
+      - name: Checking contents of `scripts` directory
+        shell: bash
+        run: shellcheck scripts/*.sh --enable=all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     tags:
       - "v*"
 
-# necessary to create releases.
 permissions:
+  # write permission is necessary to create releases.
   contents: write
 
 env:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Configuration for markdownlint
+
+# MD013/line-length
+MD013: false
+
+# MD059/descriptive-link-text
+MD059: false

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
+
 ## SQLite database format
+
 The Autobib command-line tool stores data locally in a [SQLite](https://sqlite.org/) database, located (in order of priority)
 
 - at the location specified by the `--database` command line option
@@ -9,23 +11,31 @@ The Autobib command-line tool stores data locally in a [SQLite](https://sqlite.o
 The goal is this section is to give a full, detailed description of the database format.
 
 ### Application identifier and database version
+
 An Autobib database can be identified by the application identifier.
 This is tracked in the SQLite `application_id` field, and can be read with
+
 ```sql
 PRAGMA application_id;
 ```
+
 The application id is hex `16611f2f` or decimal `375463727`.
 This is the `sha256` hash of the string `Autobib`:
+
 ```sh
 echo -n "Autobib" | sha256 | head -c 8
 ```
+
 The database version is tracked in the SQLite `user_version` tag, and can be read with
+
 ```sql
 PRAGMA user_version;
 ```
 
 ### `Records` table
+
 This table has schema
+
  ```sql
  CREATE TABLE Records (
      key INTEGER PRIMARY KEY,
@@ -34,9 +44,13 @@ This table has schema
      modified TEXT NOT NULL
  ) STRICT;
  ```
+
  This table stores the record data, and the associated canonical id, as well as the last modified time.
+
 ### `CitationKeys` table
+
 This table has schema
+
 ```sql
 CREATE TABLE CitationKeys (
     name TEXT NOT NULL PRIMARY KEY,
@@ -47,11 +61,14 @@ CREATE TABLE CitationKeys (
         ON UPDATE CASCADE ON DELETE CASCADE
 ) STRICT, WITHOUT ROWID;
 ```
+
 This table stores the keys which are used to lookup records.
 Canonical ids, reference ids, and aliases are all stored in this table.
 
 ### `Changelog` table
+
 This table has schema
+
  ```sql
  CREATE TABLE Changelog (
      record_id TEXT NOT NULL,
@@ -59,42 +76,56 @@ This table has schema
      modified TEXT NOT NULL
  ) STRICT;
  ```
+
 Whenever a row in the `Records` table is modified or deleted, the row is copied into the `Changelog` table as a backup.
 
 ### `NullRecords` table
+
 This table has schema
+
 ```sql
  CREATE TABLE NullRecords (
      record_id TEXT NOT NULL PRIMARY KEY,
      attempted TEXT NOT NULL
  ) STRICT;
  ```
+
 This table records the failed lookups if a provided record is invalid.
 
 ## Internal binary data format
+
 We use a custom internal binary format to represent the data associated with each bibTex entry.
 
 The data is stored as
-```
+
+```txt
 VERSION(u8), DATA(..)
 ```
+
 The first byte is the version.
 Depending on the version, the format of `DATA` is as follows.
 
 ### Version 0
+
 The data is stored as a sequence of blocks.
+
 ```txt
 TYPE, DATA[0], DATA[1], ..
 ```
+
 The `TYPE` consists of
+
 ```txt
 [entry_type_len: u8, entry_type: [u8..]]
 ```
+
 Here, `entry_type_len` is the length of `entry_type`, which has length at most `u8::MAX`.
 Then, each block `DATA` is of the form
+
 ```txt
 [key_len: u8, value_len: u16, key: [u8..], value: [u8..]]
 ```
+
 where `key_len` is the length of the first `key` segment, and the `value_len` is
 the length of the `value` segment. Necessarily, `key` and `value` have lengths at
 most `u8::MAX` and `u16::MAX` respectively.
@@ -105,11 +136,15 @@ The `DATA[i]` are sorted by `key` and each `key` and `entry_type` must be ASCII 
 `entry_type` can be any valid UTF-8.
 
 ## Lookup flow
+
 Given a CLI call of the form
-```
+
+```sh
 autobib <source>:<sub_id>
 ```
+
 perform the following lookup:
+
 ```txt
     ┏━━━━━━━━━━━━━━━┓
     ┃INPUT: RecordId┃

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
+# Autobib
+
 > [!WARNING]
 > Autobib is **beta software**.
-> 
+>
 > - Things might be broken.
 > - Your data might be deleted.
 > - The interface may change between releases.
-> 
+>
 > On the other hand, core functionality of Autobib is currently quite stable (and under regular use by the authors).
 > If you use this software, please:
 >
 > - Keep regular backups of the `$XDG_DATA_HOME/autobib` directory, which contains the key user files which may be modified by this program.
 > - Follow updates by reading the [changelog files](docs/changelog).
 > - Report any issues in the [issues page](https://github.com/autobib/autobib/issues).
-
-# Autobib
 
 Autobib is a command-line tool for managing bibliographic records.
 Unlike other bibliography management tools such as [Zotero](https://www.zotero.org/) or [JabRef](https://www.jabref.org/), Autobib aims to be a lower-level tool for providing an interface between *local records*, *remote records*, and *bibliographic records associated with a project*.
@@ -24,21 +24,24 @@ Moreover, Autobib is designed with first-class support for [BibTeX](https://en.w
 Pre-compiled binaries for recent tagged releases can be found on the [releases page](https://github.com/autobib/autobib/releases).
 
 If you use Homebrew, then you can also install Autobib through our tap:
-```bash
+
+```sh
 brew tap autobib/autobib
 brew install autobib
 ```
 
 If a binary is not available for your platform, you can install from source.
 Make sure the [rust toolchain](https://www.rust-lang.org/tools/install) is installed on your device and run
-```bash
+
+```sh
 cargo install --locked autobib
 ```
 
 ## Basic usage
 
 To see all the commands available with Autobib, run
-```bash
+
+```sh
 autobib help
 autobib help <subcommand>
 ```
@@ -59,10 +62,13 @@ Jump to:
 
 At its most basic, Autobib converts *identifiers* into *records*.
 To obtain the data associated with the zbMath record [`Zbl 1337.28015`](https://zbmath.org/1528.14024), running
-```bash
+
+```sh
 autobib get zbl:1337.28015
 ```
+
 will return
+
 ```bib
 @article{zbl:1337.28015,
   author = {Hochman, Michael},
@@ -77,6 +83,7 @@ will return
   zbmath = {06346461},
 }
 ```
+
 An identifier is a pair `provider:sub_id`.
 The currently supported providers are:
 
@@ -94,6 +101,7 @@ If your preferred format is not supported, feel free to [open an issue](https://
 ### Sourcing from files
 
 A more common scenario is that you have a file, say `main.tex`, with some contents:
+
 ```tex
 % contents of file `main.tex`
 \documentclass{article}
@@ -101,10 +109,13 @@ A more common scenario is that you have a file, say `main.tex`, with some conten
 We refer the reader to \cite{zbl:1337.28015,zbl:1409.11054}.
 \end{document}
 ```
+
 Then, for example, running
-```bash
+
+```sh
 autobib source main.tex --out main.bib
 ```
+
 will search through the document for valid citation keys and output the bibliography into the file `main.bib`.
 
 ### Modifying records
@@ -113,9 +124,11 @@ On the first run, Autobib retrieves the data directly from a remote provider.
 The data is stored locally in a [SQLite](https://www.sqlite.org/) database, so that subsequent runs are substantially faster.
 
 You can view and modify the internally stored record with
-```bash
+
+```sh
 autobib edit zbl:1337.28015
 ```
+
 If the record does not yet exist in your local record database, it will be retrieved before editing.
 
 You can also re-retrieve a record from the remote provider using the `autobib update` command, or remove one from the database using the `autobib delete` command.
@@ -125,10 +138,13 @@ Run `autobib help update` and `autobib help delete` for more details.
 
 It is also possible to assign *aliases* to records, using the `autobib alias` sub-command.
 To create an alias for the record with identifier `zbl:1337.28015`, run
-```bash
+
+```sh
 autobib alias add hochman-entropy zbl:1337.28015
 ```
+
 Then running `autobib get hochman-entropy` returns
+
 ```bib
 @article{hochman-entropy,
   author = {Hochman, Michael},
@@ -143,17 +159,20 @@ Then running `autobib get hochman-entropy` returns
   zbmath = {06346461},
 }
 ```
+
 The record is identical to the record `zbl:1337.28015`, except that the citation key is the name of the alias.
 In order to distinguish from usual identifiers, an alias cannot contain the colon `:`.
 
 Note that the characters `{}(),=\#%"` and [whitespace](https://doc.rust-lang.org/reference/whitespace.html) are not permitted in a BibTeX entry key.
 You can still create aliases using these characters: for instance, `autobib alias add % zbl:1337.28015` works.
 However, attempting to retrieve the BibTeX entry associated with this alias will result in an error.
-```
+
+```txt
 $ autobib get %
 ERROR Invalid bibtex entry key: %
   Suggested fix: use an alias which does not contain disallowed characters: {}(),=\#%"
 ```
+
 Run `autobib help alias` for more options for managing aliases.
 
 Aliases can be used in most locations that the usual identifiers are used.
@@ -162,12 +181,14 @@ Note that these edits will apply to the original underlying record.
 
 Many providers have default key formats; for instance, zbMath internally uses keys of the form `zbMATH06346461`.
 Autobib can be configured to automatically convert aliases matching certain rules to `provider:sub_id` pairs.
-For example, to convert `zbMATH06346461` to `zbmath:06346461` and automatically generate permanent aliases in your database, use the `[alias_transform]` in your [configuration](#database-and-configuration-file):
+For example, to convert `zbMATH06346461` to `zbmath:06346461` and automatically generate permanent aliases in your database, use the `[alias_transform]` in your [configuration](#user-data-and-configuration-file):
+
 ```toml
 [alias_transform]
 rules = [["^zbMATH([0-9]{8})$", "zbmath"]]
 create_alias = true
 ```
+
 Read the [default configuration](src/config/default_config.toml) for more detail.
 
 ### Creating local records
@@ -175,17 +196,21 @@ Read the [default configuration](src/config/default_config.toml) for more detail
 Sometimes, it is necessary to create a local record which may not otherwise exist on a remote database.
 In order to do this, the command `autobib local` can be used to generate a special `local:` record, which only exists locally in the database.
 For example,
-```bash
+
+```sh
 autobib local my-entry
 ```
+
 creates a record under the identifier `local:my-entry`.
 You will be prompted to fill in the record, unless you pass the `-I`/`--no-interactive` flag.
 To modify the record later, run the above command again or use the [`autobib edit` command](#modifying-records).
 
 It is also possible to create the local record from a BibTeX file:
-```bash
+
+```sh
 autobib -I local my-entry --from source.bib
 ```
+
 Note that the BibTeX file should contain exactly one entry, or this command will fail.
 
 When you create the local record `local:my-entry`, a new alias `my-entry` (if available) is also created and assigned to the new record.
@@ -197,9 +222,11 @@ In order to search for records which are saved on your local database, use the `
 This will open a fuzzy picker for searching through various fields.
 Specify the fields that you would like with `-f`, followed by a comma-separated list of fields.
 For example,
-```bash
+
+```sh
 autobib find -f author,title
 ```
+
 will list all of your local records with the `author` and `title` fields available to search against.
 
 ### Importing records
@@ -222,7 +249,6 @@ Note that the `[alias_transform]` section of the [configuration](src/config/defa
 This can be used to define a custom import pattern.
 To handle colons in entry keys, use the `--replace-colons` option to specify a (possibly empty) replacement string.
 
-
 ### Shell completions
 
 Autobib supports shell completion of commands and options in shells like Bash and Zsh.
@@ -233,21 +259,26 @@ See [supported shells](https://docs.rs/clap_complete/latest/clap_complete/aot/en
 > Follow the instructions [here](https://docs.brew.sh/Shell-Completion) to have your shell load the Homebrew-managed completions.
 
 A shell completions script can be generated as follows:
+
 ```sh
 autobib completions <shell>
 ```
+
 Run this on interactive shell start-up and redirect the output to your preferred directory of completions scripts.
 
 For example, in Zsh, add the following lines to `~/.zshrc`:
+
 ```sh
 if type autobib &> /dev/null
 then
   autobib completions zsh > "$HOME/.local/share/zsh/site-functions/_autobib"
 fi
 ```
+
 and make sure `~/.local/share/zsh/site-functions` (or another directory of your choice) is added to the `FPATH` environment variable.
 
 In Bash, add the following lines to `~/.profile`:
+
 ```sh
 if type autobib &> /dev/null
 then
@@ -257,6 +288,7 @@ fi
 
 For this to take effect, remember to restart your shell or source the relevant file.
 Then you can try typing `autobib f` and pressing the tab key.
+<!-- markdownlint-disable-next-line MD038 -->
 You should see `autobib find `.
 
 ### User data and configuration file

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,15 +13,17 @@
    It will also create a draft release with all of the release binaries.
 9. Go to the 'releases' tab on GitHub and publish the draft release.
 
-
 ## Automation
 
 A convenience step has been created to automate steps 1-5.
 The script can be find in [`scripts/release.sh`](scripts/release.sh) and can be run with
-```
+
+```sh
 ./scripts/release.sh {major, minor, patch, rc, beta, alpha}
 ```
+
 This script requires that the following tools are installed
+
 - [`sed`](https://www.gnu.org/software/sed/) (GNU-compatible)
 - [`cargo-edit`](https://crates.io/crates/cargo-edit)
 - [`yq`](https://mikefarah.gitbook.io/yq)

--- a/docs/changelog/v0.2.0.md
+++ b/docs/changelog/v0.2.0.md
@@ -1,4 +1,5 @@
 # Version 0.2.0 (2024-11-26)
+
 Maximum supported database version: `0`
 
 Changes since v0.1.0.
@@ -7,10 +8,10 @@ Changes since v0.1.0.
 
 - The sub-id of a local record identifier must now be a valid alias, _i.e._ it must not be empty and must not contain a colon.
     Leading and trailing whitespace is also trimmed.
-    - This means `local:`, `local: `, and `local::` etc are no longer valid identifiers.
+  - This means `local:`, `local:`, and `local::` etc are no longer valid identifiers.
         If you have such an identifier in your database (you can check with `autobib util check`), then you can rename it.
         For example, run `autobib local --rename-from ':' colon` to rename `local::` to `local:colon`.
-    - `autobib local ' foo '` creates `local:foo` instead of `local: foo `.
+  - `autobib local ' foo '` creates `local:foo` instead of `local: foo`.
 - `autobib info` now takes the report type via the `-r`/`--report` option.
 - `autobib local` no longer has the `--edit` option.
     The user is now prompted for editing by default.
@@ -18,22 +19,22 @@ Changes since v0.1.0.
 ## New features
 
 - New command `autobib update` updates the data associated with an existing citation key.
-    - It supports re-retrieving from the remote provider, or reading update data from file with the `-f`/`--from` option.
-    - It prompts for user input if there is a conflict between the current and incoming records.
-    - The `--prefer-current` and `--prefer-incoming` options are useful for non-interactive conflict resolution.
+  - It supports re-retrieving from the remote provider, or reading update data from file with the `-f`/`--from` option.
+  - It prompts for user input if there is a conflict between the current and incoming records.
+  - The `--prefer-current` and `--prefer-incoming` options are useful for non-interactive conflict resolution.
 - New command `autobib delete` deletes records and their associated keys.
-    - It prompts for user confirmation if a record to be deleted has a key that was not supplied in the arguments.
-    - The `--force` option is available for deletion without prompting.
+  - It prompts for user confirmation if a record to be deleted has a key that was not supplied in the arguments.
+  - The `--force` option is available for deletion without prompting.
 - New global option `--no-interactive` is useful for using Autobib headlessly.
-    - It stops the editor from being opened when running `autobib edit` and `autobib local`, implies the `--prefer-current` option for `autobib update`, and otherwise results in an error if user action is required.
-    - The option is switched on automatically if the standard input is not a terminal.
+  - It stops the editor from being opened when running `autobib edit` and `autobib local`, implies the `--prefer-current` option for `autobib update`, and otherwise results in an error if user action is required.
+  - The option is switched on automatically if the standard input is not a terminal.
 - `autobib edit` has two new options:
-    - `--normalize-whitespace` turns on automatic whitespace normalization;
-    - `--set-eprint` allows setting the "eprint" and "eprinttype" BibTeX fields from the provided fields.
+  - `--normalize-whitespace` turns on automatic whitespace normalization;
+  - `--set-eprint` allows setting the "eprint" and "eprinttype" BibTeX fields from the provided fields.
 - `autobib get` and `autobib source` now suggest valid equivalent keys for an invalid BibTeX citation key.
 - `autobib get` and `autobib source` can have their output suppressed with the `--retrieve-only` option.
 - `autobib local` creates an alias that is the same as the sub-id of a new local record if the alias is available.
-    - This behaviour can be disabled with the `--no-alias` option.
+  - This behaviour can be disabled with the `--no-alias` option.
 - `autobib local` supports renaming an existing record with the `--rename-from` option.
 - `autobib source` now supports LaTeX .aux files.
 - `autobib update` can report the last modified time of a cached record.

--- a/docs/changelog/v0.3.0.md
+++ b/docs/changelog/v0.3.0.md
@@ -4,6 +4,7 @@ This version introduces explicit database versioning.
 The database is automatically migrated to the newest supported version on startup.
 
 To run the migration code, report the database version, and validate your local files on update after updating, run
+
 ```sh
 autobib -v util check
 ```

--- a/docs/changelog/v0.4.0.md
+++ b/docs/changelog/v0.4.0.md
@@ -1,4 +1,5 @@
 # Version 0.4.0 (2025-09-22)
+
 Supported database versions: `<= 1`
 
 Changes since `v0.3.0`.

--- a/docs/changelog/v0.4.1.md
+++ b/docs/changelog/v0.4.1.md
@@ -1,8 +1,8 @@
 # Version 0.4.1 (2025-10-04)
+
 Supported database versions: `<= 1`
 
 Changes since `v0.4.0`.
-
 
 ## New features
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,5 @@
 # Convenience scripts
+
 This directory contains `bash` scripts to automate certain functionality.
 
 - [`test.sh`](test.sh): Automate tests with a local cache mechanism to reduce network requests. Depends on:

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,23 +2,30 @@
 
 The testing facade can benefit from local caching of response data to reduce the number of network requests required for the tests to succeed.
 In order to generate the cache, run
-```bash
+
+```sh
 xargs -- cargo run --locked --features write_response_cache -- -vv get --retrieve-only --ignore-null < 'tests/remotes.txt'
 ```
+
 This will generate a file `responses.dat` in your working directory.
 You can choose an alternative location by setting the `AUTOBIB_RESPONSE_CACHE_PATH` environment variable.
 
 After generating the response cache, you can (optionally) read from the response cache while testing by running
+
 ```sh
 cargo test --features read_response_cache
 ```
 
 ## Automated testing
+
 In order to automate the above steps, and also run other checks, you can use [`scripts/test.sh`](../scripts/test.sh):
+
 ```sh
 ./scripts/test.sh
 ```
+
 This script has the following dependencies:
+
 - [`shellcheck`](https://www.shellcheck.net/)
 
 The script automatically generates the cache files in paths the form `cache/test-cache-*/responses.dat`, and uses `cache/records.db` as a temporary database file to generate new caches.


### PR DESCRIPTION
See https://github.com/DavidAnson/markdownlint for rule definitions and configuration schema. See https://github.com/DavidAnson/markdownlint-cli2 for the command line tool that corresponds to the GitHub Action used.

When fixing existing lint errors, I disabled two rules in `.markdownlint.yaml` and made an ad-hoc exception in `README.md:291`. I didn't go through the entire list of lints and check if there were anything else to disable.