### PR TITLE
Rename RELEASE.md and fix two typos

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -15,8 +15,8 @@
 
 ## Automation
 
-A convenience step has been created to automate steps 1-5.
-The script can be find in [`scripts/release.sh`](scripts/release.sh) and can be run with
+A convenience script has been created to automate steps 1-5.
+The script can be found in [`scripts/release.sh`](scripts/release.sh) and can be run with
 ```sh
 ./scripts/release.sh {major, minor, patch, rc, beta, alpha}
 ```


### PR DESCRIPTION
Moves `RELEASE.md` to `docs/release.md`