### PR TITLE
Implement a missed `todo!()` in the code

### DIFF
--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -30,8 +30,8 @@ pub enum KeyParseErrorKind {
     ExtraBracket,
     #[error("Unexpected character: {0}")]
     UnexpectedChar(char),
-    #[error("Invalid literal: {0}")]
-    InvalidLiteral(#[from] serde_json::Error),
+    #[error("Invalid JSON literal")]
+    InvalidLiteral,
     #[error("A conditional block is missing a value.")]
     IncompleteConditional,
     #[error("Expected {0}, received {1}")]

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -179,7 +179,11 @@ impl<'a> Lexer<'a> {
                         let cutoff = idx + 2;
                         let s = match serde_json::from_str(&self.remainder()[..cutoff]) {
                             Ok(s) => s,
-                            Err(_) => todo!(),
+                            Err(_) => {
+                                return Err(
+                                    self.step_err(cutoff, KeyParseErrorKind::InvalidLiteral)
+                                );
+                            }
                         };
                         return Ok(Some(self.step_ok(cutoff, Kind::String(s))));
                     }


### PR DESCRIPTION
Fixes a missed `todo!()` related to JSON parsing in the template parse code.