### PR TITLE
Fix zbmath

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -256,20 +256,20 @@ impl Template {
         let mut ctx = init();
         for span in self.template.spans() {
             match span {
-                Span::Expr(Expression::Bare(Atom::FieldKey(k))) => {
-                    if !contains(k.as_ref(), &mut ctx) {
-                        return false;
-                    }
+                Span::Expr(Expression::Bare(Atom::FieldKey(k)))
+                    if !contains(k.as_ref(), &mut ctx) =>
+                {
+                    return false;
                 }
-                Span::Expr(Expression::IfDefined(k1, Atom::FieldKey(k2))) => {
-                    if contains(k1.as_ref(), &mut ctx) && !contains(k2.as_ref(), &mut ctx) {
-                        return false;
-                    }
+                Span::Expr(Expression::IfDefined(k1, Atom::FieldKey(k2)))
+                    if contains(k1.as_ref(), &mut ctx) && !contains(k2.as_ref(), &mut ctx) =>
+                {
+                    return false;
                 }
-                Span::Expr(Expression::IfUndefined(k1, Atom::FieldKey(k2))) => {
-                    if !contains(k1.as_ref(), &mut ctx) && !contains(k2.as_ref(), &mut ctx) {
-                        return false;
-                    }
+                Span::Expr(Expression::IfUndefined(k1, Atom::FieldKey(k2)))
+                    if !contains(k1.as_ref(), &mut ctx) && !contains(k2.as_ref(), &mut ctx) =>
+                {
+                    return false;
                 }
                 _ => {}
             }

--- a/src/provider/zbmath.rs
+++ b/src/provider/zbmath.rs
@@ -7,11 +7,9 @@ use self::response::Response;
 pub fn is_valid_id(id: &str) -> ValidationOutcome {
     if id.len() == 8 && id.as_bytes().iter().all(u8::is_ascii_digit) {
         ValidationOutcome::Valid
-    } else if id.len() == 7 && id.as_bytes().iter().all(u8::is_ascii_digit) {
-        let mut normalized = String::with_capacity(8);
-        normalized.push('0');
-        normalized.push_str(id);
-        ValidationOutcome::Normalize(normalized)
+    } else if id.len() <= 7 && id.as_bytes().iter().all(u8::is_ascii_digit) {
+        // the `id.is_empty()` case is handled globally
+        ValidationOutcome::Normalize(format!("{id:0>8}"))
     } else {
         ValidationOutcome::Invalid
     }

--- a/src/provider/zbmath/response.rs
+++ b/src/provider/zbmath/response.rs
@@ -16,6 +16,7 @@ impl TryFrom<Entry> for MutableEntryData {
             language,
             database,
             identifier,
+            year,
             ..
         } = value;
 
@@ -112,6 +113,7 @@ impl TryFrom<Entry> for MutableEntryData {
             record_data.check_and_insert_if_non_null("volume", ser.volume)?;
             record_data.check_and_insert_if_non_null("year", ser.year)?;
         }
+        record_data.check_and_insert_if_non_null("year", year)?;
 
         Ok(record_data)
     }
@@ -146,7 +148,7 @@ pub struct Entry {
     links: Vec<Link>,
     source: Source,
     title: Title,
-    // year: Option<String>,
+    year: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -253,16 +255,16 @@ pub enum LinkType {
     Arxiv,
     #[serde(rename = "doi")]
     Doi,
-    #[serde(rename = "euclid")]
-    Euclid,
-    #[serde(rename = "eudml")]
-    Eudml,
-    #[serde(rename = "oeis")]
-    Oeis,
-    #[serde(rename = "http")]
-    Http,
-    #[serde(rename = "https")]
-    Https,
+    // #[serde(rename = "euclid")]
+    // Euclid,
+    // #[serde(rename = "eudml")]
+    // Eudml,
+    // #[serde(rename = "oeis")]
+    // Oeis,
+    // #[serde(rename = "http")]
+    // Http,
+    // #[serde(rename = "https")]
+    // Https,
     #[serde(other)]
     Unknown,
 }


### PR DESCRIPTION
Fixes the zbmath issues pointed out in #279 and #280

I wonder if 0-padding to 8 digits is correct. Maybe the normalization should instead strip leading zeros instead? Unfortunately this requires database version bump (to correctly migrate the previous `zbmath:` identifiers) but might be a good idea in case there are eventually 9 digits, somehow.