### PR TITLE
Release version 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "autobib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 readme = "README.md"
 keywords = ["cli", "bibtex", "biblatex", "bibliography"]
 categories = ["command-line-utilities"]
-version = "0.6.0"
+version = "0.6.1"
 rust-version = "1.94"
 edition = "2024"
 

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -1,10 +1,1 @@
 # Unreleased
-
-Changes since `v0.5.1`.
-
-## Fixes
-
-- `zbmath` provider fixes (thanks @tornaria for the reports!):
-  - Capture `year` field in more cases
-  - Better handling of unknown link types
-  - Handle identifiers of any length, instead of only allowing length `7` or `8`

--- a/docs/changelog/v0.6.1.md
+++ b/docs/changelog/v0.6.1.md
@@ -1,0 +1,10 @@
+# Version 0.6.1 (2026-05-06)
+
+Changes since `v0.6.0`.
+
+## Fixes
+
+- `zbmath` provider fixes (thanks @tornaria for the reports!):
+  - Capture `year` field in more cases
+  - Ignore unknown link types
+  - Handle identifiers of any length, instead of only allowing length `7` or `8`


### PR DESCRIPTION
I thought it would be good to release a patch version which includes the zbmath fixes, independently of changing the internal format which we should do in `v0.7.0` (if at all).

@wupr 