### PR TITLE
Allow compiling without bundled SQLite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ rust-version = "1.94"
 edition = "2024"
 
 [features]
+default = ["bundled-sqlite"]
+bundled-sqlite = ["rusqlite/bundled"]
 in_memory_database = []
 read_response_cache = ["dep:bincode"]
 write_response_cache = ["dep:bincode", "in_memory_database"]
@@ -40,7 +42,7 @@ ramify = "0.9.0"
 regex = "1.11"
 regex-syntax = "0.8"
 rsxiv = { version = "0.4.3", features = ["serde"] }
-rusqlite = { version = "0.39", features = ["bundled", "chrono", "functions"] }
+rusqlite = { version = "0.39", features = ["chrono", "functions"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bibtex = "0.7.1"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Make sure the [rust toolchain](https://www.rust-lang.org/tools/install) is insta
 ```sh
 cargo install --locked autobib
 ```
+See the [build docs](docs/build.md) for more options.
 
 ## Basic usage
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+fn main() {
+    println!("cargo::rerun-if-env-changed=LIBSQLITE3_SYS_USE_PKG_CONFIG");
+
+    let bundled_sqlite = std::env::var_os("CARGO_FEATURE_BUNDLED_SQLITE").is_some();
+    let use_pkg_config =
+        std::env::var_os("LIBSQLITE3_SYS_USE_PKG_CONFIG").map(|value| value != "0");
+
+    match (bundled_sqlite, use_pkg_config) {
+        (true, Some(true)) => {
+            println!(
+                "cargo::error=`LIBSQLITE3_SYS_USE_PKG_CONFIG` requests system SQLite via \
+                 pkg-config, but the `bundled-sqlite` Cargo feature is enabled. Set \
+                 `LIBSQLITE3_SYS_USE_PKG_CONFIG=0` or disable the `bundled-sqlite` feature."
+            );
+            std::process::exit(1);
+        }
+        (false, Some(false)) => {
+            println!(
+                "cargo::error=`LIBSQLITE3_SYS_USE_PKG_CONFIG=0` disables system SQLite via \
+                 pkg-config, but the `bundled-sqlite` Cargo feature is disabled. Set \
+                 `LIBSQLITE3_SYS_USE_PKG_CONFIG=1` or enable the `bundled-sqlite` feature."
+            );
+            std::process::exit(1);
+        }
+        _ => {}
+    }
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,40 @@
+# Build configuration
+
+## Bundling SQLite
+
+By default, Autobib compiles with a bundled copy of SQLite enabled by the `bundled-sqlite` Cargo feature.
+To link against the SQLite library available on your system instead, disable this feature:
+
+```sh
+cargo install --locked autobib --no-default-features
+```
+This makes the binary about 1.5MB smaller, at the cost of potential compatibility issues.
+Note that the system SQLite library must be version 3.35.0 or newer.
+If this is not the case, Autobib will fail with a runtime error.
+
+Note that Autobib is only tested against the bundled SQLite configuration by default, so using the system SQLite copy may result in difficult-to-diagnose errors.
+You can run the test script to check compatibility with your system SQLite library using
+```sh
+LIBSQLITE3_SYS_USE_PKG_CONFIG=1 ./scripts/test.sh
+```
+Note that the bundled copy of SQLite is compiled with the following flags:
+```sh
+SQLITE_DEFAULT_MEMSTATUS=0
+SQLITE_DEFAULT_WAL_SYNCHRONOUS=1
+SQLITE_DQS=0
+SQLITE_LIKE_DOESNT_MATCH_BLOBS
+SQLITE_MAX_EXPR_DEPTH=0
+SQLITE_OMIT_DEPRECATED
+SQLITE_OMIT_PROGRESS_CALLBACK
+SQLITE_OMIT_SHARED_CACHE
+SQLITE_STRICT_SUBTYPE=1
+```
+
+## Dynamically link musl targets
+
+By default, musl targets are statically linked.
+In order to dynamically link on musl, the simplest way is to manually overwrite `RUSTFLAGS`:
+```sh
+RUSTFLAGS="" cargo build --release
+```
+You can also manually override the target configuration using the `--config` option of `cargo build`.

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -1,1 +1,9 @@
 # Unreleased
+
+Changes since `v0.6.1`.
+
+## Breaking
+
+- SQLite is now only bundled when the Cargo feature `bundled-sqlite` is enabled.
+  This feature is enabled by default, but this may cause breakage with builds using `--no-default-features`.
+  Disabling this feature will cause the compiled binary to link to your SQLite system library instead.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,21 +19,27 @@ CACHE_DIR="${CACHE_ROOT}/test-cache-${HASH}"
 
 export AUTOBIB_RESPONSE_CACHE_PATH="${CACHE_DIR}/responses.dat"
 
+if [[ "${LIBSQLITE3_SYS_USE_PKG_CONFIG:-0}" != "0" ]]; then
+    FEATURE_ARGS=(--no-default-features)
+else
+    FEATURE_ARGS=()
+fi
+
 if [[ ! -f "${AUTOBIB_RESPONSE_CACHE_PATH}" ]]; then
     echo 2>&1 "Cache file not found. Generating cache file: ${AUTOBIB_RESPONSE_CACHE_PATH}"
 
     mkdir -p "${CACHE_DIR}"
 
     # Generate the cache file
-    cargo run --locked --features write_response_cache -- -vv source --retrieve-only --ignore-null "${REMOTES_FILE}"
+    cargo run --locked "${FEATURE_ARGS[@]}" --features write_response_cache -- -vv source --retrieve-only --ignore-null "${REMOTES_FILE}"
 else
     echo 2>&1 "Cache file found: ${AUTOBIB_RESPONSE_CACHE_PATH}"
 fi
 
-cargo test --locked --no-fail-fast --features read_response_cache -- "$@"
+cargo test --locked --no-fail-fast "${FEATURE_ARGS[@]}" --features read_response_cache -- "$@"
 
-cargo doc --no-deps --locked
-cargo clippy --locked
+cargo doc --no-deps --locked "${FEATURE_ARGS[@]}"
+cargo clippy --locked "${FEATURE_ARGS[@]}"
 cargo fmt --check
 sort -C "${REMOTES_FILE}"
 REPETITIONS="$(uniq -d < "${REMOTES_FILE}" | wc -w)"

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,6 +151,20 @@ impl RecordDatabase {
         #[cfg(feature = "in_memory_database")]
         let mut conn = Connection::open_in_memory_with_flags(flags)?;
 
+        #[cfg(not(feature = "bundled-sqlite"))]
+        {
+            if !read_only {
+                // 3.35, since this is when the RETURNING class is introduced
+                if rusqlite::version_number() < 3_035_000 {
+                    return Err(DatabaseError::UnsupportedSQLiteVersion(rusqlite::version()));
+                }
+
+                // we only need this when using system sqlite since the bundled version is compiled
+                // so that foreign keys are always enabled at startup
+                conn.pragma_update(None, "foreign_keys", "ON")?;
+            }
+        }
+
         Self::initialize(&mut conn, read_only)?;
 
         Ok(Self { conn })

--- a/src/error/database.rs
+++ b/src/error/database.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum DatabaseError {
     #[error("SQLite error: {0}")]
     SQLiteError(#[from] rusqlite::Error),
+    #[error("System SQLite version {0} is too old. Minimum supported SQLite version is 3.35.0")]
+    UnsupportedSQLiteVersion(&'static str),
     #[error("Error while migrating from old database (version v'{0}'): '{1}'")]
     Migration(i32, String),
     #[error(

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,7 @@ In order to automate the above steps, and also run other checks, you can use [`s
 ```sh
 ./scripts/test.sh
 ```
+Set `LIBSQLITE3_SYS_USE_PKG_CONFIG=1` to run the tests using the SQLite library available on your system instead of a bundled copy of SQLite.
 This script has the following dependencies:
 
 - [`shellcheck`](https://www.shellcheck.net/)


### PR DESCRIPTION
This makes it possible to compile without bundling SQLite.

Bundling SQLite is now behind a feature flag called `bundled-sqlite` which is enabled by default.

If SQLite is not bundled, some additional things are done at runtime:

1. enabling foreign keys (which is not done by default since the bundled SQLite copy is compiled with a flag to always enable foreign keys on startup)
2. checking that the runtime SQLite is >= 3.35

I also updated the test script to check for `AUTOBIB_USE_SYSTEM_SQLITE = 1` which then builds the response cache / runs the tests with system SQLite.

Fixes #285 (and provides a more reasonable option downstream)