### PR TITLE
Preserve release target rustflags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
   RUST_BACKTRACE: 1
   RUST_VERSION: ${{ vars.RUST_VERSION }}
@@ -163,7 +162,9 @@ jobs:
       - name: Build release binary
         shell: bash
         run: |
-          cargo build --verbose --release --locked --target ${{ matrix.target }}
+          cargo build --verbose --release --locked \
+            --config 'target."cfg(all())".rustflags = ["-D", "warnings"]' \
+            --target ${{ matrix.target }}
           if [[ "${{ matrix.image }}" = "windows-latest" ]]; then
             bin="target/${{ matrix.target }}/release/autobib.exe"
           else


### PR DESCRIPTION
Possible fix for #294 

I changed this PR: now it sets `-D warnings` in `.cargo/config.toml` globally. It might be slightly annoying for warnings to upgrade to errors whenever one runs `cargo build`, but I think the benefit of all of the configuration being in one place outweighs the downsides.

Previously, this  manually set the `cfg(all)` target when invoking `cargo build --release`. If you have a convincing reason why this is better, I am happy to hear it!

See https://doc.rust-lang.org/cargo/reference/config.html#targetcfgrustflags for documentation of this behaviour.