### PR TITLE
Add autobib list

### DIFF
--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -11,9 +11,9 @@ Changes since `v0.6.1`.
 ## Added
 
 - New command `autobib list` which prints records using the template syntax.
-- Added new template meta `%bibtex`, which expands to the full bibtex record.
+- Added new template meta `%bibtex`, which expands to the full BibTeX record.
 
 ## Changed
 
-- Renamed `autobib util list` to `autobib util print-keys`.
+- Renamed `autobib util list` to `autobib util print-identifiers`.
   `autobib util list` is still usable as an alias, but this will be removed in the future.

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -11,6 +11,7 @@ Changes since `v0.6.1`.
 ## Added
 
 - New command `autobib list` which prints records using the template syntax.
+- Added new template meta `%bibtex`, which expands to the full bibtex record.
 
 ## Changed
 

--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -7,3 +7,12 @@ Changes since `v0.6.1`.
 - SQLite is now only bundled when the Cargo feature `bundled-sqlite` is enabled.
   This feature is enabled by default, but this may cause breakage with builds using `--no-default-features`.
   Disabling this feature will cause the compiled binary to link to your SQLite system library instead.
+
+## Added
+
+- New command `autobib list` which prints records using the template syntax.
+
+## Changed
+
+- Renamed `autobib util list` to `autobib util print-keys`.
+  `autobib util list` is still usable as an alias, but this will be removed in the future.

--- a/docs/template.md
+++ b/docs/template.md
@@ -105,6 +105,7 @@ When used, this flag only formats if all of the field keys which would be render
 The precise behaviour depends on the command:
 
 - `autobib find`: Any record missing a key is omitted from the search interface.
+- `autobib list`: Any record missing a key is omitted from the output.
 
 Strict mode prevents rendering if rendering the template would require expanding a field key which does not exist in the provided data.
 For example:

--- a/docs/template.md
+++ b/docs/template.md
@@ -74,6 +74,7 @@ These are all prefixed by the `%` character:
 - `%full_id`: expands to the full canonical id, e.g. `zbmath:06346461`.
 - `%provider`: expands to the provider of the canonical id: e.g. `zbmath`
 - `%sub_id`: expands to the sub-id of the canonical id: e.g. `06346461`
+- `%bibtex`: expands to the full BibTeX record with entry key given by the value of `%full_id`, or placeholder text `::` if `%full_id` is not a valid BibTeX key.
 
 Finally, it is possible to input a *string*, i.e. a [JSON string](https://www.json.org/json-en.html), by quoting text.
 This allows manually inputting invisible characters or specifying Unicode values using escapes by including the value in quotes:

--- a/src/app.rs
+++ b/src/app.rs
@@ -339,7 +339,8 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
                         // only perform normalization
                         let record_data = MutableEntryData::from_entry_data(&data);
                         let entry = Entry {
-                            key: EntryKey::try_new(key).unwrap_or_else(|_| EntryKey::placeholder()),
+                            key: EntryKey::try_new(key)
+                                .unwrap_or_else(|_| EntryKey::<String>::placeholder()),
                             record_data,
                         };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1213,7 +1213,7 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
                     record_db.evict_cache()?;
                 }
             },
-            UtilCommand::PrintKeys { canonical, deleted } => {
+            UtilCommand::PrintIdentifiers { canonical, deleted } => {
                 let mut lock = stdout_lock_wrap();
                 let snapshot = record_db.snapshot()?;
                 if canonical {

--- a/src/app.rs
+++ b/src/app.rs
@@ -454,6 +454,16 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
                 }
             }
         }
+        Command::List { template, strict } => {
+            let mut lock = stdout_lock_wrap();
+            record_db.map_active_records(|row_data| {
+                if strict && !template.has_keys_contained_in(&row_data) {
+                    return Ok(());
+                }
+
+                template.render_io(&mut lock, &row_data)
+            })?;
+        }
         Command::Get {
             identifiers,
             out,
@@ -1202,7 +1212,7 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
                     record_db.evict_cache()?;
                 }
             },
-            UtilCommand::List { canonical, deleted } => {
+            UtilCommand::PrintKeys { canonical, deleted } => {
                 let mut lock = stdout_lock_wrap();
                 let snapshot = record_db.snapshot()?;
                 if canonical {

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -547,7 +547,7 @@ impl UtilCommand {
     /// Check if the command is read-only compatible.
     pub fn validate_read_only_compatibility(&self) -> Result<(), ReadOnlyInvalid> {
         match self {
-            Self::PrintKeys { .. } | Self::Check { fix: false } => Ok(()),
+            Self::PrintIdentifiers { .. } | Self::Check { fix: false } => Ok(()),
             Self::Check { fix: true, .. } => Err(ReadOnlyInvalid::Argument("--fix")),
             Self::Optimize => Err(ReadOnlyInvalid::Command("util optimize")),
             Self::Evict { .. } => Err(ReadOnlyInvalid::Command("util evict")),
@@ -744,7 +744,7 @@ pub enum UtilCommand {
     ///
     /// The deprecated `list` alias has the same behaviour.
     #[command(alias = "list")]
-    PrintKeys {
+    PrintIdentifiers {
         /// Only print the canonical identifiers.
         #[arg(short, long)]
         canonical: bool,

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -323,6 +323,14 @@ pub enum Command {
         #[arg(short = 'a', long)]
         create_alias: bool,
     },
+    /// Print every record in the database using a template.
+    List {
+        /// The template to use for printing.
+        template: Template,
+        /// Only include records which contain all of the fields in the template.
+        #[arg(short, long)]
+        strict: bool,
+    },
     /// Display the revision history associated with an identifier.
     Log {
         /// The identifier.
@@ -539,7 +547,7 @@ impl UtilCommand {
     /// Check if the command is read-only compatible.
     pub fn validate_read_only_compatibility(&self) -> Result<(), ReadOnlyInvalid> {
         match self {
-            Self::List { .. } | Self::Check { fix: false } => Ok(()),
+            Self::PrintKeys { .. } | Self::Check { fix: false } => Ok(()),
             Self::Check { fix: true, .. } => Err(ReadOnlyInvalid::Argument("--fix")),
             Self::Optimize => Err(ReadOnlyInvalid::Command("util optimize")),
             Self::Evict { .. } => Err(ReadOnlyInvalid::Command("util evict")),
@@ -558,6 +566,7 @@ impl Command {
             | Self::Completions { .. }
             | Self::DefaultConfig
             | Self::Find { .. }
+            | Self::List { .. }
             | Self::Log { .. }
             | Self::Path { mkdir: false, .. } => return Ok(()),
             Self::Path { mkdir: true, .. } => return Err(ReadOnlyInvalid::Argument("--mkdir")),
@@ -731,12 +740,15 @@ pub enum UtilCommand {
         #[arg(long)]
         max_age: Option<u32>,
     },
-    /// List all valid identifiers.
-    List {
-        /// Only list the canonical identifiers.
+    /// Print all valid identifiers.
+    ///
+    /// The deprecated `list` alias has the same behaviour.
+    #[command(alias = "list")]
+    PrintKeys {
+        /// Only print the canonical identifiers.
         #[arg(short, long)]
         canonical: bool,
-        /// List deleted identifiers instead of those with data.
+        /// Print deleted identifiers instead of those with data.
         #[arg(short, long)]
         deleted: bool,
     },

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -73,7 +73,7 @@ where
         let record_data = MutableEntryData::<String>::default();
         let entry = Entry {
             key: EntryKey::try_new(remote_id.name().into())
-                .unwrap_or_else(|_| EntryKey::placeholder()),
+                .unwrap_or_else(|_| EntryKey::<String>::placeholder()),
             record_data,
         };
 

--- a/src/app/write.rs
+++ b/src/app/write.rs
@@ -7,12 +7,10 @@ use std::{
 
 use itertools::Itertools;
 use nonempty::NonEmpty;
-use serde::Serializer as _;
-use serde_bibtex::ser::Serializer;
 
 use crate::{
     Identifier,
-    entry::{Entry, EntryData},
+    entry::{Bibliography, Entry, EntryData},
     logger::warn,
     output::stdout_lock_wrap,
     record::RemoteId,
@@ -90,10 +88,8 @@ pub fn output_entries<D: EntryData>(
 fn write_entries<W: io::Write, D: EntryData>(
     writer: W,
     grouped_entries: BTreeMap<RemoteId, NonEmpty<Entry<D>>>,
-) -> Result<(), serde_bibtex::Error> {
-    let mut serializer = Serializer::unchecked(writer);
-
-    serializer.collect_seq(grouped_entries.iter().flat_map(|(canonical, entry_group)| {
+) -> Result<(), io::Error> {
+    let all_entries_iter = grouped_entries.iter().flat_map(|(canonical, entry_group)| {
         if entry_group.len() > 1 {
             warn!(
                 "Multiple keys for '{canonical}': {}",
@@ -101,5 +97,7 @@ fn write_entries<W: io::Write, D: EntryData>(
             );
         };
         entry_group
-    }))
+    });
+
+    Bibliography::new(all_entries_iter).write_io(writer)
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -38,7 +38,7 @@ use crate::{
     error::DatabaseError,
     logger::{debug, error, info, warn},
 };
-pub use snapshot::Snapshot;
+pub use snapshot::{Snapshot, SnapshotMapErr};
 
 /// The current database version expected by the application.
 pub const fn user_version() -> i32 {
@@ -418,6 +418,8 @@ impl RecordDatabase {
     /// The provided `filter_map` closure plays a similar role to [`Iterator::filter_map`]
     /// by transforming a [`RecordRow`] into the picker item type, with the option to exclude
     /// the item from being sent to the matcher entirely by returning [`None`].
+    ///
+    /// This is a wrapper around [`map_active_records`](Self::map_active_records).
     pub fn inject_active_records<T, F, R>(
         &mut self,
         injector: Injector<T, R>,
@@ -427,15 +429,29 @@ impl RecordDatabase {
         F: FnMut(RecordRow<RawEntryData>) -> Option<T>,
         R: Render<T>,
     {
-        debug!("Sending all database records to an injector.");
+        self.map_active_records(|res| {
+            if let Some(data) = filter_map(res) {
+                injector.push(data);
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    /// Iterate over all active entries in the Records table and apply the fallible closure
+    /// `f` to each row. If an error is returned by the closure, it is immediately propagated and
+    /// the function exits early.
+    pub fn map_active_records<E, F>(&mut self, mut f: F) -> Result<(), SnapshotMapErr<E>>
+    where
+        F: FnMut(RecordRow<RawEntryData>) -> Result<(), E>,
+    {
+        debug!("Mapping over all active database records.");
         let mut retriever = self
             .conn
             .prepare("SELECT record_id, modified, data, variant FROM Records WHERE key IN (SELECT record_key FROM Identifiers) AND variant = 0")?;
 
         for res in retriever.query_map([], |row| Ok(RecordRow::from_row_unchecked(row)))? {
-            if let Some(data) = filter_map(res?) {
-                injector.push(data);
-            }
+            f(res?).map_err(SnapshotMapErr::CallbackFailed)?;
         }
 
         Ok(())

--- a/src/db/snapshot.rs
+++ b/src/db/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, str::from_utf8};
+use std::{convert::Infallible, error, fmt, str::from_utf8};
 
 use chrono::{DateTime, Local};
 use rusqlite::types::ValueRef;
@@ -18,6 +18,13 @@ pub struct Snapshot<'conn> {
 pub enum SnapshotMapErr<E> {
     CallbackFailed(E),
     DatabaseError(rusqlite::Error),
+}
+
+impl From<SnapshotMapErr<Infallible>> for rusqlite::Error {
+    fn from(value: SnapshotMapErr<Infallible>) -> Self {
+        let SnapshotMapErr::DatabaseError(err) = value;
+        err
+    }
 }
 
 impl<E> From<rusqlite::Error> for SnapshotMapErr<E> {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,11 +1,11 @@
 mod data;
 mod deserialize;
 
-use std::{fmt, str::FromStr};
+use std::{fmt, io, str::FromStr};
 
 use delegate::delegate;
 use serde::ser::{Serialize, SerializeSeq, SerializeStruct, Serializer};
-use serde_bibtex::{MacroDictionary, de::Deserializer, to_string_unchecked};
+use serde_bibtex::{MacroDictionary, de::Deserializer, ser::Formatter};
 
 pub use self::data::{
     BorrowedEntryData, ConflictResolved, EntryData, EntryEditCommand, EntryKey, EntryType,
@@ -104,10 +104,53 @@ impl FromStr for Entry<MutableEntryData> {
 
 impl<D: EntryData, S: AsRef<str>> fmt::Display for Entry<D, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct FormatterWriter<'a, 'b> {
+            formatter: &'a mut fmt::Formatter<'b>,
+            failed: bool,
+        }
+
+        impl io::Write for FormatterWriter<'_, '_> {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                // SAFETY: serde_bibtex only emits calls which are valid strings
+                let s = unsafe { std::str::from_utf8_unchecked(buf) };
+                if self.formatter.write_str(s).is_err() {
+                    self.failed = true;
+                    return Err(io::Error::other(fmt::Error));
+                }
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        struct NoTrailingNewlineFormatter;
+
+        impl Formatter for NoTrailingNewlineFormatter {
+            fn write_bibliography_end<W>(&mut self, _: &mut W) -> io::Result<()>
+            where
+                W: ?Sized + io::Write,
+            {
+                Ok(())
+            }
+        }
+
         // SAFETY: the RecordData::try_new and RecordData::check_and_insert methods only accept
         //         entry types and field keys which satisfy stricter requirements than the
         //         serde_bibtex syntax
-        let buffer = to_string_unchecked(&[self]).expect("serialization should not fail");
-        f.write_str(&buffer)
+        let mut writer = FormatterWriter {
+            formatter: f,
+            failed: false,
+        };
+        let mut ser = serde_bibtex::ser::Serializer::new_with_formatter(
+            &mut writer,
+            NoTrailingNewlineFormatter,
+        );
+        match [self].serialize(&mut ser) {
+            Ok(()) => Ok(()),
+            Err(_) if writer.failed => Err(fmt::Error),
+            Err(err) => panic!("serialization should not fail: {err}"),
+        }
     }
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -4,8 +4,7 @@ mod deserialize;
 use std::{fmt, io, str::FromStr};
 
 use delegate::delegate;
-use serde::ser::{Serialize, SerializeSeq, SerializeStruct, Serializer};
-use serde_bibtex::{MacroDictionary, de::Deserializer, ser::Formatter};
+use serde_bibtex::{MacroDictionary, de::Deserializer};
 
 pub use self::data::{
     BorrowedEntryData, ConflictResolved, EntryData, EntryEditCommand, EntryKey, EntryType,
@@ -40,35 +39,100 @@ impl<D: EntryData, S> Entry<D, S> {
         to self.record_data {
             pub fn fields(&self) -> impl Iterator<Item = (&str, &str)>;
             pub fn entry_type(&self) -> &str;
+            pub fn entry_type_and_fields(&self) -> (&str, impl Iterator<Item = (&str, &str)>);
         }
     }
 }
 
-struct RecordDataWrapper<D>(D);
+trait EntryWrite {
+    type Error;
 
-impl<D: EntryData> Serialize for RecordDataWrapper<&'_ D> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_seq(None)?;
-        for (key, value) in self.0.fields() {
-            state.serialize_element(&(key, value))?;
-        }
-        state.end()
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), Self::Error>;
+}
+
+impl<W: EntryWrite> EntryWrite for &mut W {
+    type Error = W::Error;
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), Self::Error> {
+        (*self).write_fmt(args)
     }
 }
 
-impl<D: EntryData, S: AsRef<str>> Serialize for Entry<D, S> {
-    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
-    where
-        T: Serializer,
-    {
-        let mut state = serializer.serialize_struct("Entry", 3)?;
-        state.serialize_field("entry_type", &self.entry_type())?;
-        state.serialize_field("entry_key", &self.key.as_ref())?;
-        state.serialize_field("fields", &RecordDataWrapper(&self.record_data))?;
-        state.end()
+struct IOWriteWrap<W>(W);
+
+impl<W: io::Write> EntryWrite for IOWriteWrap<W> {
+    type Error = io::Error;
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), Self::Error> {
+        self.0.write_fmt(args)
+    }
+}
+
+struct FmtWriteWrap<W>(W);
+
+impl<W: fmt::Write> EntryWrite for FmtWriteWrap<W> {
+    type Error = fmt::Error;
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> Result<(), Self::Error> {
+        self.0.write_fmt(args)
+    }
+}
+
+impl<D: EntryData, S: AsRef<str>> Entry<D, S> {
+    fn write_generic<W: EntryWrite>(&self, mut writer: W) -> Result<(), W::Error> {
+        let (entry_type, fields) = self.entry_type_and_fields();
+        writeln!(writer, "@{}{{{},", entry_type, self.key.as_ref())?;
+        for (key, value) in fields {
+            writeln!(writer, "  {key} = {{{value}}},")?;
+        }
+        write!(writer, "}}")
+    }
+
+    pub fn write_io<W: io::Write>(&self, writer: W) -> Result<(), io::Error> {
+        self.write_generic(IOWriteWrap(writer))
+    }
+
+    pub fn write_fmt<W: fmt::Write>(&self, writer: W) -> Result<(), fmt::Error> {
+        self.write_generic(FmtWriteWrap(writer))
+    }
+}
+impl<D: EntryData, S: AsRef<str>> fmt::Display for Entry<D, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write_fmt(f)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Bibliography<E> {
+    entries: E,
+}
+
+impl<'r, E, D, S> Bibliography<E>
+where
+    D: EntryData + 'r,
+    S: AsRef<str> + 'r,
+    E: Iterator<Item = &'r Entry<D, S>>,
+{
+    pub fn new(entries: E) -> Self {
+        Self { entries }
+    }
+
+    fn write_generic<W: EntryWrite>(self, mut writer: W) -> Result<(), W::Error> {
+        let mut first = true;
+        for entry in self.entries {
+            if first {
+                first = false;
+            } else {
+                write!(writer, "\n\n")?;
+            }
+
+            entry.write_generic(&mut writer)?;
+        }
+        writeln!(writer)
+    }
+
+    pub fn write_io<W: io::Write>(self, writer: W) -> Result<(), io::Error> {
+        self.write_generic(IOWriteWrap(writer))
     }
 }
 
@@ -98,59 +162,6 @@ impl FromStr for Entry<MutableEntryData> {
             }
             Some(Err(err)) => Err(Self::Err::BibtexParseError(err)),
             None => Err(Self::Err::Empty),
-        }
-    }
-}
-
-impl<D: EntryData, S: AsRef<str>> fmt::Display for Entry<D, S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        struct FormatterWriter<'a, 'b> {
-            formatter: &'a mut fmt::Formatter<'b>,
-            failed: bool,
-        }
-
-        impl io::Write for FormatterWriter<'_, '_> {
-            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                // SAFETY: serde_bibtex only emits calls which are valid strings
-                let s = unsafe { std::str::from_utf8_unchecked(buf) };
-                if self.formatter.write_str(s).is_err() {
-                    self.failed = true;
-                    return Err(io::Error::other(fmt::Error));
-                }
-                Ok(buf.len())
-            }
-
-            fn flush(&mut self) -> io::Result<()> {
-                Ok(())
-            }
-        }
-
-        struct NoTrailingNewlineFormatter;
-
-        impl Formatter for NoTrailingNewlineFormatter {
-            fn write_bibliography_end<W>(&mut self, _: &mut W) -> io::Result<()>
-            where
-                W: ?Sized + io::Write,
-            {
-                Ok(())
-            }
-        }
-
-        // SAFETY: the RecordData::try_new and RecordData::check_and_insert methods only accept
-        //         entry types and field keys which satisfy stricter requirements than the
-        //         serde_bibtex syntax
-        let mut writer = FormatterWriter {
-            formatter: f,
-            failed: false,
-        };
-        let mut ser = serde_bibtex::ser::Serializer::new_with_formatter(
-            &mut writer,
-            NoTrailingNewlineFormatter,
-        );
-        match [self].serialize(&mut ser) {
-            Ok(()) => Ok(()),
-            Err(_) if writer.failed => Err(fmt::Error),
-            Err(err) => panic!("serialization should not fail: {err}"),
         }
     }
 }

--- a/src/entry/data.rs
+++ b/src/entry/data.rs
@@ -65,6 +65,13 @@ pub unsafe trait EntryData: PartialEq {
     /// Get the `entry_type` as a string slice.
     fn entry_type(&self) -> &str;
 
+    /// Get the fields and entry type at the same time.
+    ///
+    /// The default implementation calls the `fields` and `entry_type` functions separately.
+    fn entry_type_and_fields(&self) -> (&str, impl Iterator<Item = (&str, &str)>) {
+        (self.entry_type(), self.fields())
+    }
+
     /// Get the exact size (in bytes) of the binary format representation of the [`EntryData`].
     ///
     /// The default implementation is performed by iterating over all fields.

--- a/src/entry/data/identifier.rs
+++ b/src/entry/data/identifier.rs
@@ -23,11 +23,17 @@ impl<S: AsRef<str>> EntryKey<S> {
         Ok(Self(s))
     }
 }
+impl EntryKey<&'static str> {
+    /// A placeholder value used for displaying keys which are not valid bibtex.
+    pub fn placeholder() -> Self {
+        Self("::")
+    }
+}
 
 impl EntryKey {
     /// A placeholder value used for displaying keys which are not valid bibtex.
     pub fn placeholder() -> Self {
-        Self(":not_valid_bibtex".to_owned())
+        Self("::".to_owned())
     }
 
     /// Substitute a character with a different entry key.

--- a/src/entry/data/raw.rs
+++ b/src/entry/data/raw.rs
@@ -329,3 +329,21 @@ unsafe impl<T: AsRef<[u8]>> EntryData for RawEntryData<T> {
         self.data.as_ref().len()
     }
 }
+
+unsafe impl<T: AsRef<[u8]>> EntryData for &RawEntryData<T> {
+    fn fields(&self) -> impl Iterator<Item = (&str, &str)> {
+        let (_, data_blocks) = self.split_blocks();
+        RawRecordFieldsIter {
+            remaining: data_blocks,
+        }
+    }
+
+    fn entry_type(&self) -> &str {
+        let (type_block, _) = self.split_blocks();
+        from_utf8(&type_block[1..]).unwrap()
+    }
+
+    fn raw_len(&self) -> usize {
+        self.data.as_ref().len()
+    }
+}

--- a/src/entry/data/raw.rs
+++ b/src/entry/data/raw.rs
@@ -325,6 +325,16 @@ unsafe impl<T: AsRef<[u8]>> EntryData for RawEntryData<T> {
         from_utf8(&type_block[1..]).unwrap()
     }
 
+    fn entry_type_and_fields(&self) -> (&str, impl Iterator<Item = (&str, &str)>) {
+        let (type_block, data_blocks) = self.split_blocks();
+        (
+            from_utf8(&type_block[1..]).unwrap(),
+            RawRecordFieldsIter {
+                remaining: data_blocks,
+            },
+        )
+    }
+
     fn raw_len(&self) -> usize {
         self.data.as_ref().len()
     }

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for KeyParseError {
 #[derive(Error, Debug)]
 pub enum KeyParseErrorKind {
     #[error(
-        "Meta '%{0}' is invalid. Accepted values:\n     %entry_type %provider %sub_id %full_id"
+        "Meta '%{0}' is invalid. Accepted values:\n     %entry_type %provider %sub_id %full_id %bibtex"
     )]
     InvalidMeta(String),
     #[error("String started with '\"' is unclosed.")]

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,6 @@
 mod parse;
 
-use std::{convert::Infallible, fmt, iter::Peekable, str::FromStr};
+use std::{convert::Infallible, fmt, io, iter::Peekable, str::FromStr};
 
 use mufmt::{Ast, Manifest, ManifestMut, Span, SyntaxError};
 use nucleo_picker::Render;
@@ -450,6 +450,21 @@ impl<'r> ManifestMut<Expression> for ManifestLarge<'r> {
         state: &mut Self::State<'_>,
     ) -> Result<impl fmt::Display, Self::Error> {
         Ok(DisplayedRow::from_data(self.0, ast, |k| state.get_field(k)))
+    }
+}
+
+impl Template {
+    /// Render the template into a writer using the provided record data.
+    pub fn render_io<W: io::Write>(
+        &self,
+        writer: W,
+        item: &RecordRow<RawEntryData>,
+    ) -> Result<(), io::Error> {
+        Ok(match self.strategy {
+            Strategy::Sorted => self.template.render_io(&ManifestSorted(item), writer),
+            Strategy::Small => self.template.render_io(&ManifestSmall(item), writer),
+            Strategy::Large => self.template.render_io(&ManifestLarge(item), writer),
+        }?)
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -9,7 +9,9 @@ use self::parse::{Kind, Lexer, Token};
 
 use crate::{
     db::{Identifier, state::RecordRow},
-    entry::{EntryData, FieldKey, MutableEntryData, RawEntryData, RawRecordFieldsIter},
+    entry::{
+        Entry, EntryData, EntryKey, FieldKey, MutableEntryData, RawEntryData, RawRecordFieldsIter,
+    },
     error::{ClapTemplateError, KeyParseError, KeyParseErrorKind},
 };
 
@@ -24,6 +26,8 @@ pub enum Meta {
     SubId,
     /// `{%full_id}`
     FullId,
+    /// `{%bibtex}`
+    Bibtex,
 }
 
 impl FromStr for Meta {
@@ -35,6 +39,7 @@ impl FromStr for Meta {
             "provider" => Ok(Self::Provider),
             "sub_id" => Ok(Self::SubId),
             "full_id" => Ok(Self::FullId),
+            "bibtex" => Ok(Self::Bibtex),
             _ => Err(KeyParseErrorKind::InvalidMeta(s.into())),
         }
     }
@@ -342,6 +347,7 @@ enum DisplayedRow<'row, 'ast, 'state> {
     Row(&'row str),
     Ast(&'ast str),
     State(&'state str),
+    Entry(&'row str, &'row RawEntryData),
     Skip,
 }
 
@@ -351,6 +357,15 @@ impl<'r, 'ast, 'state> fmt::Display for DisplayedRow<'r, 'ast, 'state> {
             Self::Row(s) => f.write_str(s),
             Self::Ast(s) => f.write_str(s),
             Self::State(s) => f.write_str(s),
+            Self::Entry(canonical, data) => {
+                let key = EntryKey::try_new(*canonical)
+                    .unwrap_or_else(|_| EntryKey::<&'static str>::placeholder());
+                let entry = Entry {
+                    key,
+                    record_data: *data,
+                };
+                entry.fmt(f)
+            }
             Self::Skip => Ok(()),
         }
     }
@@ -394,6 +409,7 @@ impl<'row, 'ast, 'state> DisplayedRow<'row, 'ast, 'state> {
                 Meta::Provider => DisplayedRow::Row(row_data.canonical.provider()),
                 Meta::SubId => DisplayedRow::Row(row_data.canonical.sub_id()),
                 Meta::FullId => DisplayedRow::Row(row_data.canonical.name()),
+                Meta::Bibtex => DisplayedRow::Entry(row_data.canonical.name(), &row_data.data),
             },
         }
     }
@@ -641,5 +657,23 @@ mod tests {
             Strategy::Sorted,
             "AAAA",
         );
+    }
+
+    #[test]
+    fn render_bibtex_meta() {
+        let template = Template::compile("{%bibtex}").unwrap();
+        let mut data = MutableEntryData::<String>::default();
+        data.check_and_insert("a".into(), "A".into()).unwrap();
+        data.check_and_insert("b".into(), "B".into()).unwrap();
+
+        let row_data = RecordRow::<RawEntryData> {
+            data: RawEntryData::from_entry_data(&data),
+            canonical: RemoteId::from_parts("local", "12345").unwrap(),
+            modified: Local::now(),
+        };
+
+        let rendered = template.render(&row_data);
+
+        assert_eq!(rendered, "@misc{local:12345,\n  a = {A},\n  b = {B},\n}");
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -700,19 +700,19 @@ fn list() -> Result<()> {
     );
 
     let mut cmd = s.cmd()?;
-    cmd.args(["util", "print-keys"]);
+    cmd.args(["util", "print-identifiers"]);
     cmd.assert()
         .success()
         .stdout(contains("zbmath:06346461").and(contains("my_alias")));
 
     let mut cmd = s.cmd()?;
-    cmd.args(["--read-only", "util", "print-keys"]);
+    cmd.args(["--read-only", "util", "print-identifiers"]);
     cmd.assert()
         .success()
         .stdout(contains("zbmath:06346461").and(contains("my_alias")));
 
     let mut cmd = s.cmd()?;
-    cmd.args(["util", "print-keys", "--canonical"]);
+    cmd.args(["util", "print-identifiers", "--canonical"]);
     cmd.assert()
         .success()
         .stdout(contains("my_alias").not().and(contains("local:first")));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -657,7 +657,7 @@ fn delete() -> Result<()> {
     s.close()
 }
 
-/// Test citation key listing.
+/// Test record and citation key listing.
 #[test]
 fn list() -> Result<()> {
     let s = TestState::init()?;
@@ -680,16 +680,42 @@ fn list() -> Result<()> {
     cmd.assert().success();
 
     let mut cmd = s.cmd()?;
-    cmd.args(["util", "list"]);
+    cmd.args(["list", "{%full_id}: {title}"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("local:first: My favourite book").and(contains(
+            "zbmath:06346461: On self-similar sets with overlaps and inverse theorems for entropy",
+        )));
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["--read-only", "list", "{%full_id}"]);
+    cmd.assert().success().stdout(contains("zbmath:06346461"));
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["list", "--strict", "{journal}: {title}"]);
+    cmd.assert().success().stdout(
+        contains("My favourite book")
+            .not()
+            .and(contains("Ann. Math.")),
+    );
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["util", "print-keys"]);
     cmd.assert()
         .success()
         .stdout(contains("zbmath:06346461").and(contains("my_alias")));
 
     let mut cmd = s.cmd()?;
-    cmd.args(["--read-only", "util", "list"]);
+    cmd.args(["--read-only", "util", "print-keys"]);
     cmd.assert()
         .success()
         .stdout(contains("zbmath:06346461").and(contains("my_alias")));
+
+    let mut cmd = s.cmd()?;
+    cmd.args(["util", "print-keys", "--canonical"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("my_alias").not().and(contains("local:first")));
 
     let mut cmd = s.cmd()?;
     cmd.args(["util", "list", "--canonical"]);


### PR DESCRIPTION
Changes:

1. Adds new command `autobib list`, which uses the template syntax to render all records in the database.
2. Renames `autobib util list` to `autobib util print-identifiers`
3. Adds a new `%bibtex` meta, which renders the record as bibtex (using a placeholder for `%full_id` if necessary)

I also removed most allocations from the `Display` implementation of `Entry`.