### PR TITLE
Add basic JSON support

### DIFF
--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -13,5 +13,7 @@ Changes since `v0.6.1`.
 ## New features
 
 - New command `autobib list` which prints records using the template syntax.
-- Added new template meta `%bibtex`, which expands to the full BibTeX record.
+- New template metas:
+  - `%bibtex`, which expands to the full BibTeX record.
+  - `%json`, which JSON encodes the record data (excluding the canonical identifier)
 - Adds basic support for sourcing from [Typst](https://typst.app) files (using `autobib source file.typ`)

--- a/docs/template.md
+++ b/docs/template.md
@@ -75,6 +75,7 @@ These are all prefixed by the `%` character:
 - `%provider`: expands to the provider of the canonical id: e.g. `zbmath`
 - `%sub_id`: expands to the sub-id of the canonical id: e.g. `06346461`
 - `%bibtex`: expands to the full BibTeX record with entry key given by the value of `%full_id`, or placeholder text `::` if `%full_id` is not a valid BibTeX key.
+- `%json`: expands to a JSON dictionary containing the entry type and fields
 
 Finally, it is possible to input a *string*, i.e. a [JSON string](https://www.json.org/json-en.html), by quoting text.
 This allows manually inputting invisible characters or specifying Unicode values using escapes by including the value in quotes:

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -247,7 +247,7 @@ pub enum Command {
         #[command(subcommand)]
         hist_command: HistCommand,
     },
-    /// Import records from a BibTeX file.
+    /// Import records from BibTeX files.
     ///
     /// The implementation automatically determines a remote identifier from the data using
     /// your `preferred_providers` config setting, or with any other remote identifier that can
@@ -282,7 +282,7 @@ pub enum Command {
         /// Attach files specified in the `file` field.
         #[arg(long)]
         include_files: bool,
-        /// A separator for the `files` BibTeX field.
+        /// A separator for the `file` field.
         #[arg(long, requires = "include_files")]
         file_sep: Option<String>,
     },

--- a/src/app/write.rs
+++ b/src/app/write.rs
@@ -10,7 +10,7 @@ use nonempty::NonEmpty;
 
 use crate::{
     Identifier,
-    entry::{Bibliography, Entry, EntryData},
+    entry::{Entry, EntryData, entries_to_bibtex},
     logger::warn,
     output::stdout_lock_wrap,
     record::RemoteId,
@@ -99,5 +99,5 @@ fn write_entries<W: io::Write, D: EntryData>(
         entry_group
     });
 
-    Bibliography::new(all_entries_iter).write_io(writer)
+    entries_to_bibtex(writer, all_entries_iter)
 }

--- a/src/db/state/disp.rs
+++ b/src/db/state/disp.rs
@@ -8,7 +8,11 @@ use chrono::{DateTime, Local};
 use crossterm::style::{ContentStyle, StyledContent, Stylize};
 
 use super::{ArbitraryDataRef, InRecordsTable, RecordRow, RevisionId, State, Version};
-use crate::{entry::EntryData, logger::LogDisplay, record::RemoteId};
+use crate::{
+    entry::{EntryData, EntryFields},
+    logger::LogDisplay,
+    record::RemoteId,
+};
 
 impl<'conn, I: InRecordsTable> LogDisplay for State<'conn, I> {
     fn log_display(&self, styled: bool, mut buf: impl std::io::Write) -> anyhow::Result<()> {
@@ -94,7 +98,7 @@ impl<'a> fmt::Display for RecordRowDisplay<'a> {
                         self.canonical
                     )?;
                 }
-                for (key, val) in raw_entry_data.fields() {
+                for (key, val) in raw_entry_data.fields().pairs() {
                     if self.styled {
                         writeln!(buf, "{PREFIX}  {} = {{{val}}},", key.blue())?;
                     } else {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -102,38 +102,24 @@ impl<D: EntryData, S: AsRef<str>> fmt::Display for Entry<D, S> {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct Bibliography<E> {
-    entries: E,
-}
-
-impl<'r, E, D, S> Bibliography<E>
+pub fn entries_to_bibtex<'r, W, E, D, S>(mut writer: W, entries: E) -> Result<(), io::Error>
 where
+    W: io::Write,
     D: EntryData + 'r,
     S: AsRef<str> + 'r,
-    E: Iterator<Item = &'r Entry<D, S>>,
+    E: IntoIterator<Item = &'r Entry<D, S>>,
 {
-    pub fn new(entries: E) -> Self {
-        Self { entries }
-    }
-
-    fn write_generic<W: EntryWrite>(self, mut writer: W) -> Result<(), W::Error> {
-        let mut first = true;
-        for entry in self.entries {
-            if first {
-                first = false;
-            } else {
-                write!(writer, "\n\n")?;
-            }
-
-            entry.write_generic(&mut writer)?;
+    let mut first = true;
+    for entry in entries {
+        if first {
+            first = false;
+        } else {
+            write!(writer, "\n\n")?;
         }
-        writeln!(writer)
-    }
 
-    pub fn write_io<W: io::Write>(self, writer: W) -> Result<(), io::Error> {
-        self.write_generic(IOWriteWrap(writer))
+        entry.write_io(&mut writer)?;
     }
+    writeln!(writer)
 }
 
 pub fn entries_from_bibtex(

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -7,8 +7,9 @@ use delegate::delegate;
 use serde_bibtex::{MacroDictionary, de::Deserializer};
 
 pub use self::data::{
-    BorrowedEntryData, ConflictResolved, EntryData, EntryEditCommand, EntryKey, EntryType,
-    FieldKey, FieldValue, MutableEntryData, RawEntryData, RawRecordFieldsIter, SetFieldCommand,
+    BorrowedEntryData, ConflictResolved, EntryData, EntryEditCommand, EntryFields, EntryKey,
+    EntryType, FieldKey, FieldValue, MutableEntryData, RawEntryData, RawRecordFieldsIter,
+    SetFieldCommand,
 };
 pub(crate) use self::data::{EntryTypeHeader, KeyHeader, ValueHeader};
 
@@ -37,9 +38,9 @@ impl<D: EntryData, S> Entry<D, S> {
 
     delegate! {
         to self.record_data {
-            pub fn fields(&self) -> impl Iterator<Item = (&str, &str)>;
+            pub fn fields(&self) -> impl EntryFields<'_>;
             pub fn entry_type(&self) -> &str;
-            pub fn entry_type_and_fields(&self) -> (&str, impl Iterator<Item = (&str, &str)>);
+            pub fn entry_type_and_fields(&self) -> (&str, impl EntryFields<'_>);
         }
     }
 }
@@ -82,7 +83,7 @@ impl<D: EntryData, S: AsRef<str>> Entry<D, S> {
     fn write_generic<W: EntryWrite>(&self, mut writer: W) -> Result<(), W::Error> {
         let (entry_type, fields) = self.entry_type_and_fields();
         writeln!(writer, "@{}{{{},", entry_type, self.key.as_ref())?;
-        for (key, value) in fields {
+        for (key, value) in fields.pairs() {
             writeln!(writer, "  {key} = {{{value}}},")?;
         }
         write!(writer, "}}")

--- a/src/entry/data.rs
+++ b/src/entry/data.rs
@@ -18,6 +18,10 @@ use std::{
 
 use delegate::delegate;
 use regex::Regex;
+use serde::{
+    Serialize, Serializer,
+    ser::{SerializeSeq, SerializeStruct},
+};
 
 pub use identifier::{EntryKey, EntryType, FieldKey, FieldValue, validate_ascii_identifier};
 pub(crate) use raw::{EntryTypeHeader, KeyHeader, ValueHeader};
@@ -48,6 +52,10 @@ pub trait BorrowedEntryData<'r>: EntryData {
     }
 }
 
+pub trait EntryFields<'r> {
+    fn pairs(&self) -> impl Iterator<Item = (&'r str, &'r str)>;
+}
+
 /// This trait represents types which encapsulate the data content of a single BibTeX entry.
 ///
 /// # Safety
@@ -60,7 +68,7 @@ pub trait BorrowedEntryData<'r>: EntryData {
 /// 3. The `(key, value)` pairs are sorted by key and no key is repeated.
 pub unsafe trait EntryData: PartialEq {
     /// Iterate over `(key, value)` pairs in order.
-    fn fields(&self) -> impl Iterator<Item = (&str, &str)>;
+    fn fields(&self) -> impl EntryFields<'_>;
 
     /// Get the `entry_type` as a string slice.
     fn entry_type(&self) -> &str;
@@ -68,7 +76,7 @@ pub unsafe trait EntryData: PartialEq {
     /// Get the fields and entry type at the same time.
     ///
     /// The default implementation calls the `fields` and `entry_type` functions separately.
-    fn entry_type_and_fields(&self) -> (&str, impl Iterator<Item = (&str, &str)>) {
+    fn entry_type_and_fields(&self) -> (&str, impl EntryFields<'_>) {
         (self.entry_type(), self.fields())
     }
 
@@ -80,6 +88,7 @@ pub unsafe trait EntryData: PartialEq {
             + (1 + self.entry_type().len()) // the entry type, plus the 1-byte header
             + self // the key value pairs, plus the 3-byte header
                 .fields()
+                .pairs()
                 .map(|(k, v)| 3 + k.len() + v.len())
                 .sum::<usize>()
     }
@@ -88,7 +97,7 @@ pub unsafe trait EntryData: PartialEq {
     ///
     /// The default implementation iterates over all fields and returns the first match.
     fn get_field<'r>(&'r self, field_name: &str) -> Option<&'r str> {
-        for (key, val) in self.fields() {
+        for (key, val) in self.fields().pairs() {
             if field_name < key {
                 return None;
             }
@@ -105,6 +114,49 @@ pub unsafe trait EntryData: PartialEq {
     /// The default implementation checks that `get_field` returns `Some(_)`.
     fn contains_field(&self, field_name: &str) -> bool {
         self.get_field(field_name).is_some()
+    }
+
+    /// Returns a wrapper which can be serialized.
+    fn serialize(&self) -> impl Serialize
+    where
+        Self: Sized,
+    {
+        struct EntryDataSer<'r, D> {
+            data: &'r D,
+        }
+
+        impl<D: EntryData> Serialize for EntryDataSer<'_, D> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                struct FieldsWrapper<F>(F);
+
+                impl<'a, F> Serialize for FieldsWrapper<F>
+                where
+                    F: EntryFields<'a>,
+                {
+                    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where
+                        S: Serializer,
+                    {
+                        let mut state = serializer.serialize_seq(None)?;
+                        for (key, value) in self.0.pairs() {
+                            state.serialize_element(&(key, value))?;
+                        }
+                        state.end()
+                    }
+                }
+
+                let mut state = serializer.serialize_struct("EntryData", 2)?;
+                let (entry_type, fields) = self.data.entry_type_and_fields();
+                state.serialize_field("entry_type", entry_type)?;
+                state.serialize_field("fields", &FieldsWrapper(fields))?;
+                state.end()
+            }
+        }
+
+        EntryDataSer { data: self }
     }
 }
 
@@ -184,7 +236,7 @@ pub enum ConflictResolved<T = FieldValue> {
 impl<'r> MutableEntryData<&'r str> {
     pub fn borrow_entry_data<D: EntryData>(data: &'r D) -> Self {
         let mut new = Self::new(EntryType(data.entry_type()));
-        for (key, value) in data.fields() {
+        for (key, value) in data.fields().pairs() {
             new.fields.insert(FieldKey(key), FieldValue(value));
         }
         new
@@ -194,7 +246,7 @@ impl<'r> MutableEntryData<&'r str> {
 impl MutableEntryData {
     pub fn from_entry_data<D: EntryData>(data: &D) -> Self {
         let mut new = Self::new(EntryType(data.entry_type().to_owned()));
-        for (key, value) in data.fields() {
+        for (key, value) in data.fields().pairs() {
             new.fields
                 .insert(FieldKey(key.to_owned()), FieldValue(value.to_owned()));
         }
@@ -278,7 +330,7 @@ impl MutableEntryData {
         self.entry_type.0.clear();
         self.entry_type.0.push_str(data.entry_type());
 
-        for (key, value) in data.fields() {
+        for (key, value) in data.fields().pairs() {
             match self.fields.get_mut(key) {
                 Some(existing) => {
                     existing.0.clear();
@@ -322,7 +374,7 @@ impl MutableEntryData {
             }
         }
 
-        for (key, value) in other.fields() {
+        for (key, value) in other.fields().pairs() {
             match self.fields.get_mut(key) {
                 Some(current_value) if current_value != value => {
                     match resolve_field_conflict(
@@ -433,11 +485,15 @@ impl<S: AsRef<str> + Ord> MutableEntryData<S> {
     }
 }
 
+impl<'r, S: AsRef<str>> EntryFields<'r> for &'r BTreeMap<identifier::FieldKey<S>, FieldValue<S>> {
+    fn pairs(&self) -> impl Iterator<Item = (&'r str, &'r str)> {
+        self.iter().map(|(k, v)| (k.as_ref(), v.as_ref()))
+    }
+}
+
 unsafe impl<S: AsRef<str> + Ord> EntryData for MutableEntryData<S> {
-    fn fields(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.fields
-            .iter()
-            .map(|(k, v)| (k.0.as_ref(), v.0.as_ref()))
+    fn fields(&self) -> impl EntryFields<'_> {
+        &self.fields
     }
 
     fn entry_type(&self) -> &str {

--- a/src/entry/data.rs
+++ b/src/entry/data.rs
@@ -20,7 +20,7 @@ use delegate::delegate;
 use regex::Regex;
 use serde::{
     Serialize, Serializer,
-    ser::{SerializeSeq, SerializeStruct},
+    ser::{SerializeMap, SerializeStruct},
 };
 
 pub use identifier::{EntryKey, EntryType, FieldKey, FieldValue, validate_ascii_identifier};
@@ -140,9 +140,9 @@ pub unsafe trait EntryData: PartialEq {
                     where
                         S: Serializer,
                     {
-                        let mut state = serializer.serialize_seq(None)?;
+                        let mut state = serializer.serialize_map(None)?;
                         for (key, value) in self.0.pairs() {
-                            state.serialize_element(&(key, value))?;
+                            state.serialize_entry(&key, &value)?;
                         }
                         state.end()
                     }

--- a/src/entry/data/raw.rs
+++ b/src/entry/data/raw.rs
@@ -58,7 +58,7 @@ use std::str::from_utf8;
 
 use serde_bibtex::token::is_balanced;
 
-use super::{BorrowedEntryData, EntryData, validate_ascii_identifier};
+use super::{BorrowedEntryData, EntryData, EntryFields, validate_ascii_identifier};
 use crate::error::InvalidBytesError;
 
 /// The size (in bytes) of the version header.
@@ -94,7 +94,7 @@ impl RawEntryData {
         data.push(entry_type_len);
         data.extend(entry_type.as_bytes());
 
-        for (key, value) in entry_data.fields() {
+        for (key, value) in entry_data.fields().pairs() {
             let key_len = KeyHeader::try_from(key.len()).unwrap();
             let value_len = ValueHeader::try_from(value.len()).unwrap().to_le_bytes();
 
@@ -312,12 +312,22 @@ impl<'r> BorrowedEntryData<'r> for RawEntryData<&'r [u8]> {
     }
 }
 
-unsafe impl<T: AsRef<[u8]>> EntryData for RawEntryData<T> {
-    fn fields(&self) -> impl Iterator<Item = (&str, &str)> {
-        let (_, data_blocks) = self.split_blocks();
+struct RawFields<'r> {
+    data: &'r [u8],
+}
+
+impl<'r> EntryFields<'r> for RawFields<'r> {
+    fn pairs(&self) -> impl Iterator<Item = (&'r str, &'r str)> {
         RawRecordFieldsIter {
-            remaining: data_blocks,
+            remaining: self.data,
         }
+    }
+}
+
+unsafe impl<T: AsRef<[u8]>> EntryData for RawEntryData<T> {
+    fn fields(&self) -> impl EntryFields<'_> {
+        let (_, data) = self.split_blocks();
+        RawFields { data }
     }
 
     fn entry_type(&self) -> &str {
@@ -325,14 +335,9 @@ unsafe impl<T: AsRef<[u8]>> EntryData for RawEntryData<T> {
         from_utf8(&type_block[1..]).unwrap()
     }
 
-    fn entry_type_and_fields(&self) -> (&str, impl Iterator<Item = (&str, &str)>) {
-        let (type_block, data_blocks) = self.split_blocks();
-        (
-            from_utf8(&type_block[1..]).unwrap(),
-            RawRecordFieldsIter {
-                remaining: data_blocks,
-            },
-        )
+    fn entry_type_and_fields(&self) -> (&str, impl EntryFields<'_>) {
+        let (type_block, data) = self.split_blocks();
+        (from_utf8(&type_block[1..]).unwrap(), RawFields { data })
     }
 
     fn raw_len(&self) -> usize {
@@ -341,16 +346,19 @@ unsafe impl<T: AsRef<[u8]>> EntryData for RawEntryData<T> {
 }
 
 unsafe impl<T: AsRef<[u8]>> EntryData for &RawEntryData<T> {
-    fn fields(&self) -> impl Iterator<Item = (&str, &str)> {
-        let (_, data_blocks) = self.split_blocks();
-        RawRecordFieldsIter {
-            remaining: data_blocks,
-        }
+    fn fields(&self) -> impl EntryFields<'_> {
+        let (_, data) = self.split_blocks();
+        RawFields { data }
     }
 
     fn entry_type(&self) -> &str {
         let (type_block, _) = self.split_blocks();
         from_utf8(&type_block[1..]).unwrap()
+    }
+
+    fn entry_type_and_fields(&self) -> (&str, impl EntryFields<'_>) {
+        let (type_block, data) = self.split_blocks();
+        (from_utf8(&type_block[1..]).unwrap(), RawFields { data })
     }
 
     fn raw_len(&self) -> usize {

--- a/src/entry/data/tests.rs
+++ b/src/entry/data/tests.rs
@@ -131,7 +131,7 @@ fn test_data_round_trip() {
 
     let mut record_data_clone = MutableEntryData::try_new(raw_data.entry_type().into()).unwrap();
 
-    for (key, value) in raw_data.fields() {
+    for (key, value) in raw_data.fields().pairs() {
         record_data_clone
             .check_and_insert(key.into(), value.into())
             .unwrap();
@@ -177,13 +177,13 @@ fn test_round_trip() {
         for (k, v) in keys {
             data.check_and_insert((*k).into(), (*v).into()).unwrap();
         }
-        assert_eq!(data.fields().count(), keys.len());
+        assert_eq!(data.fields().pairs().count(), keys.len());
 
         let raw_data = RawEntryData::from_entry_data(&data);
-        assert_eq!(raw_data.fields().count(), keys.len());
+        assert_eq!(raw_data.fields().pairs().count(), keys.len());
 
         let new_data = MutableEntryData::from_entry_data(&raw_data);
-        assert_eq!(new_data.fields().count(), keys.len());
+        assert_eq!(new_data.fields().pairs().count(), keys.len());
 
         for (k, v) in keys {
             assert_eq!(raw_data.get_field(k), Some(*v));

--- a/src/entry/deserialize.rs
+++ b/src/entry/deserialize.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use serde::de::{self, Deserializer, Error, SeqAccess, Unexpected, Visitor};
 
@@ -82,8 +82,8 @@ impl<'de> de::Deserialize<'de> for FieldValue {
             ))
         } else {
             // SAFETY: we do not check for the 'balanced `{}`' rule here because this rule is
-            // automatically checked during bibtex deserialization process, and if we get it wrong,
-            // it will not result in data corruption (just invalid output)
+            // automatically checked when parsing bibtex, and if we get it wrong, it will
+            // not result in data corruption (just invalid output)
             Ok(Self(inner))
         }
     }
@@ -109,11 +109,11 @@ impl<'de> de::Deserialize<'de> for Entry<MutableEntryData> {
             {
                 let entry_type: EntryType<String> = seq
                     .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
                 let entry_key: String = seq
                     .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let fields: std::collections::BTreeMap<FieldKey<String>, FieldValue<String>> = seq
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let fields: BTreeMap<FieldKey<String>, FieldValue<String>> = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(2, &self))?;
                 Ok(Entry {

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for KeyParseError {
 #[derive(Error, Debug)]
 pub enum KeyParseErrorKind {
     #[error(
-        "Meta '%{0}' is invalid. Accepted values:\n     %entry_type %provider %sub_id %full_id %bibtex"
+        "Meta '%{0}' is invalid. Accepted values:\n     %entry_type %provider %sub_id %full_id %bibtex %json"
     )]
     InvalidMeta(String),
     #[error("String started with '\"' is unclosed.")]

--- a/src/format.rs
+++ b/src/format.rs
@@ -28,6 +28,8 @@ pub enum Meta {
     FullId,
     /// `{%bibtex}`
     Bibtex,
+    /// `{%json}`
+    Json,
 }
 
 impl FromStr for Meta {
@@ -40,6 +42,7 @@ impl FromStr for Meta {
             "sub_id" => Ok(Self::SubId),
             "full_id" => Ok(Self::FullId),
             "bibtex" => Ok(Self::Bibtex),
+            "json" => Ok(Self::Json),
             _ => Err(KeyParseErrorKind::InvalidMeta(s.into())),
         }
     }
@@ -348,6 +351,7 @@ enum DisplayedRow<'row, 'ast, 'state> {
     Ast(&'ast str),
     State(&'state str),
     Entry(&'row str, &'row RawEntryData),
+    Json(&'row RawEntryData),
     Skip,
 }
 
@@ -365,6 +369,39 @@ impl<'r, 'ast, 'state> fmt::Display for DisplayedRow<'r, 'ast, 'state> {
                     record_data: *data,
                 };
                 entry.fmt(f)
+            }
+            Self::Json(data) => {
+                struct FormatterAdapter<'a, 'b>(&'a mut fmt::Formatter<'b>);
+
+                impl io::Write for FormatterAdapter<'_, '_> {
+                    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                        let s = unsafe {
+                            // serde_json does not emit invalid UTF-8
+                            std::str::from_utf8_unchecked(buf)
+                        };
+
+                        match self.0.write_str(s) {
+                            Ok(()) => Ok(s.len()),
+                            Err(fmt::Error) => Err(io::ErrorKind::Other.into()),
+                        }
+                    }
+
+                    fn flush(&mut self) -> io::Result<()> {
+                        Ok(())
+                    }
+                }
+
+                let adapter = FormatterAdapter(f);
+                match serde_json::to_writer(adapter, &data.serialize()) {
+                    Ok(()) => Ok(()),
+                    Err(err) => {
+                        if err.is_io() {
+                            Err(fmt::Error)
+                        } else {
+                            panic!("JSON serialization should not fail")
+                        }
+                    }
+                }
             }
             Self::Skip => Ok(()),
         }
@@ -410,6 +447,7 @@ impl<'row, 'ast, 'state> DisplayedRow<'row, 'ast, 'state> {
                 Meta::SubId => DisplayedRow::Row(row_data.canonical.sub_id()),
                 Meta::FullId => DisplayedRow::Row(row_data.canonical.name()),
                 Meta::Bibtex => DisplayedRow::Entry(row_data.canonical.name(), &row_data.data),
+                Meta::Json => DisplayedRow::Json(&row_data.data),
             },
         }
     }
@@ -675,5 +713,26 @@ mod tests {
         let rendered = template.render(&row_data);
 
         assert_eq!(rendered, "@misc{local:12345,\n  a = {A},\n  b = {B},\n}");
+    }
+
+    #[test]
+    fn render_json_meta() {
+        let template = Template::compile("{%json}").unwrap();
+        let mut data = MutableEntryData::<String>::default();
+        data.check_and_insert("a".into(), "A".into()).unwrap();
+        data.check_and_insert("b".into(), "B".into()).unwrap();
+
+        let row_data = RecordRow::<RawEntryData> {
+            data: RawEntryData::from_entry_data(&data),
+            canonical: RemoteId::from_parts("local", "12345").unwrap(),
+            modified: Local::now(),
+        };
+
+        let rendered = template.render(&row_data);
+
+        assert_eq!(
+            rendered,
+            r#"{"entry_type":"misc","fields":{"a":"A","b":"B"}}"#
+        );
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -19,7 +19,7 @@ use ureq::http::StatusCode;
 // re-imports exposed to provider implementations
 use crate::{
     MappedKey, RemoteId,
-    entry::{EntryData, EntryType, MutableEntryData},
+    entry::{EntryData, EntryFields, EntryType, MutableEntryData},
     error::{ProviderError, RecordDataError},
     http::{BodyBytes, Client},
 };
@@ -189,7 +189,7 @@ pub fn determine_remote_id_candidates<K: Ord, D: EntryData, F: FnMut(&RemoteId) 
         (c, s)
     });
     // first determine candidates using provider-specific fields
-    for (name, value) in data.fields() {
+    for (name, value) in data.fields().pairs() {
         if let Some(provider) = field_name_to_provider(name) {
             update_in_place(provider, value, &mut score, &mut bc, &mut br);
         }


### PR DESCRIPTION
Adds basic JSON support in templates.

For example, as long as your keys do not contain unencoded JSON characters (mainly `\`), you can use
```sh
autobib list '"{%full_id}": {%json}' --prefix "{" --sep "," --suffix "}"
```
to get a JSON dict containing all of the active records in your database.