### PR TITLE
Disallow control characters in aliases

### DIFF
--- a/docs/changelog/next.md
+++ b/docs/changelog/next.md
@@ -9,6 +9,8 @@ Changes since `v0.6.1`.
   Disabling this feature will cause the compiled binary to link to your SQLite system library instead.
 - Renamed `autobib util list` to `autobib util print-identifiers`.
   `autobib util list` is still usable as an alias, but this will be removed in the future.
+- Aliases can no longer contain control characters.
+  - Existing aliases containing control characters can still be accessed and renamed.
 
 ## New features
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -897,6 +897,9 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
                         bail!("local sub-id must contain non-whitespace characters")
                     }
                     AliasErrorKind::IsRemoteId => bail!("local sub-id must not contain a colon"),
+                    AliasErrorKind::ContainsControl => {
+                        bail!("local sub-id must not contain control characters")
+                    }
                 },
             };
             let remote_id = RemoteId::local(&alias);

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -19,7 +19,7 @@ use crate::{
     entry::{EntryType, FieldKey, SetFieldCommand},
     error::ShortError,
     format::Template,
-    record::{Alias, RecordId},
+    record::{Alias, LegacyAlias, RecordId},
 };
 
 /// Determine the default value for `no_interactive` based on interactivity of stdin and stderr.
@@ -311,7 +311,7 @@ pub enum Command {
         /// The name for the record.
         id: String,
         /// Create the record using the provided BibTeX data.
-        #[arg(short = 'b', long, value_name = "PATH", group = "input")]
+        #[arg(short = 'b', long, value_name = "PATH")]
         from_bibtex: Option<PathBuf>,
         /// Set the entry type.
         #[arg(long, value_name = "ENTRY_TYPE")]
@@ -515,9 +515,9 @@ pub enum AliasCommand {
     #[command(alias = "mv")]
     Rename {
         /// The name of the existing alias.
-        #[arg(value_parser = with_short_err::<Alias>)]
-        alias: Alias,
+        alias: LegacyAlias,
         /// The name of the new alias.
+        #[arg(value_parser = with_short_err::<Alias>)]
         new: Alias,
     },
     /// Reassign an existing alias to refer to a new record.

--- a/src/db.rs
+++ b/src/db.rs
@@ -37,6 +37,7 @@ use crate::{
     entry::RawEntryData,
     error::DatabaseError,
     logger::{debug, error, info, warn},
+    record::LegacyAlias,
 };
 pub use snapshot::{Snapshot, SnapshotMapErr};
 
@@ -483,13 +484,13 @@ impl RecordDatabase {
     /// Rename an alias, returning the status of the renaming.
     pub fn rename_alias(
         &mut self,
-        old: &Alias,
+        old: &LegacyAlias,
         new: &Alias,
     ) -> Result<RenameAliasResult, rusqlite::Error> {
         let mut updater = self
             .conn
             .prepare("UPDATE Identifiers SET name = ?1 WHERE name = ?2")?;
-        match flatten_constraint_violation(updater.execute((new.name(), old.name())))? {
+        match flatten_constraint_violation(updater.execute((new.name(), old.as_ref())))? {
             Constraint::Satisfied(_) => Ok(RenameAliasResult::Renamed),
             Constraint::Violated => Ok(RenameAliasResult::TargetExists),
         }

--- a/src/error/record.rs
+++ b/src/error/record.rs
@@ -108,6 +108,7 @@ pub struct AliasConversionError {
 pub enum AliasErrorKind {
     Empty,
     IsRemoteId,
+    ContainsControl,
 }
 
 impl AliasErrorKind {
@@ -115,6 +116,7 @@ impl AliasErrorKind {
         match self {
             Self::Empty => "alias must contain non-whitespace characters",
             Self::IsRemoteId => "alias must not contain a colon",
+            Self::ContainsControl => "alias must not contain control characters",
         }
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -4,7 +4,9 @@ mod mapped;
 use anyhow::bail;
 use nonempty::NonEmpty;
 
-pub use self::key::{Alias, AliasOrRemoteId, MappedAliasOrRemoteId, MappedKey, RecordId, RemoteId};
+pub use self::key::{
+    Alias, AliasOrRemoteId, LegacyAlias, MappedAliasOrRemoteId, MappedKey, RecordId, RemoteId,
+};
 use crate::{
     Config,
     config::AliasTransform,

--- a/src/record/key.rs
+++ b/src/record/key.rs
@@ -211,27 +211,76 @@ impl FromStr for Alias {
     type Err = AliasConversionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let trimmed = s.trim();
-        if trimmed.is_empty() {
-            Err(AliasConversionError {
-                input: s.to_owned(),
+        let input = s.trim().to_owned();
+
+        if input.is_empty() {
+            return Err(AliasConversionError {
+                input,
                 kind: AliasErrorKind::Empty,
-            })
-        } else {
-            match trimmed.find(':') {
-                Some(_) => Err(AliasConversionError {
-                    input: s.to_owned(),
-                    kind: AliasErrorKind::IsRemoteId,
-                }),
-                None => Ok(Self(trimmed.to_owned())),
-            }
+            });
         }
+
+        if input.find(':').is_some() {
+            return Err(AliasConversionError {
+                input,
+                kind: AliasErrorKind::IsRemoteId,
+            });
+        }
+
+        if input.chars().any(char::is_control) {
+            return Err(AliasConversionError {
+                input,
+                kind: AliasErrorKind::ContainsControl,
+            });
+        }
+
+        Ok(Self(input))
     }
 }
 
 impl fmt::Display for Alias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+/// A validated legacy `alias`.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct LegacyAlias(String);
+
+impl FromStr for LegacyAlias {
+    type Err = AliasConversionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let input = s.trim().to_owned();
+
+        if input.is_empty() {
+            return Err(AliasConversionError {
+                input,
+                kind: AliasErrorKind::Empty,
+            });
+        }
+
+        if input.find(':').is_some() {
+            return Err(AliasConversionError {
+                input,
+                kind: AliasErrorKind::IsRemoteId,
+            });
+        }
+
+        Ok(Self(input))
+    }
+}
+
+impl fmt::Display for LegacyAlias {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AsRef<str> for LegacyAlias {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 


### PR DESCRIPTION
Disallow control characters in aliases (and, by extension, in `local:...` records).

- Existing records can be retrieved by name without issue (since `RecordId` does no validation).
- In order to rename aliases, this modifies `autobib alias rename` so that the old alias is validated according to the previous rules.
