### PR TITLE
Fix alias issues

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -349,7 +349,7 @@ pub fn run_cli<C: Client>(cli: Cli, client: &C) -> Result<()> {
                         {
                             let new_row =
                                 row.modify(&RawEntryData::from_entry_data(&record_data))?;
-                            if key.as_ref() != entry.key.as_ref() {
+                            if key.as_ref() != entry.key.as_ref() && !key.is_placeholder() {
                                 create_alias_if_valid(key.as_ref(), &new_row)?;
                             }
                             new_row.commit()?;

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -508,13 +508,14 @@ pub enum AliasCommand {
     #[command(alias = "rm")]
     Delete {
         /// The existing alias to delete.
-        #[arg(value_parser = with_short_err::<Alias>)]
-        alias: Alias,
+        #[arg(value_parser = with_short_err::<LegacyAlias>)]
+        alias: LegacyAlias,
     },
     /// Rename an existing alias.
     #[command(alias = "mv")]
     Rename {
         /// The name of the existing alias.
+        #[arg(value_parser = with_short_err::<LegacyAlias>)]
         alias: LegacyAlias,
         /// The name of the new alias.
         #[arg(value_parser = with_short_err::<Alias>)]

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -82,7 +82,7 @@ where
 
         if let Some(Entry { key, record_data }) = Editor::new_bibtex().edit(&entry)? {
             let row = missing.insert(&RawEntryData::from_entry_data(&record_data), remote_id)?;
-            if key.as_ref() != remote_id.name() {
+            if key.as_ref() != remote_id.name() && !key.is_placeholder() {
                 create_alias_if_valid(key.as_ref(), &row)?;
             }
             row.commit()?;

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -14,7 +14,7 @@ use crate::{
         ConflictResolved, Entry, EntryData, EntryEditCommand, EntryKey, MutableEntryData,
         RawEntryData,
     },
-    error::MergeError,
+    error::{MergeError, ShortError},
     logger::{error, info, reraise, set_failed, suggest, warn},
     normalize::{Normalization, Normalize},
     record::{Alias, RemoteId},
@@ -32,7 +32,10 @@ pub fn create_alias_if_valid(key: &str, row: &State<IsEntry>) -> Result<(), rusq
             }
         }
         Err(err) => {
-            error!("Bibtex key '{key}' is not a valid alias: {err}.");
+            error!(
+                "Bibtex key '{key}' is not a valid alias: {}.",
+                err.short_err()
+            );
             suggest!("Edits to the entry key are only used to create new aliases.");
         }
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -497,11 +497,14 @@ impl RecordDatabase {
     }
 
     /// Delete an alias, returning the status of the deletion.
-    pub fn delete_alias(&mut self, alias: &Alias) -> Result<DeleteAliasResult, rusqlite::Error> {
+    pub fn delete_alias(
+        &mut self,
+        alias: &LegacyAlias,
+    ) -> Result<DeleteAliasResult, rusqlite::Error> {
         let mut deleter = self
             .conn
             .prepare("DELETE FROM Identifiers WHERE name = ?1")?;
-        if deleter.execute((alias.name(),))? == 0 {
+        if deleter.execute((alias.as_ref(),))? == 0 {
             Ok(DeleteAliasResult::Missing)
         } else {
             Ok(DeleteAliasResult::Deleted)

--- a/src/entry/data/identifier.rs
+++ b/src/entry/data/identifier.rs
@@ -22,7 +22,12 @@ impl<S: AsRef<str>> EntryKey<S> {
 
         Ok(Self(s))
     }
+
+    pub fn is_placeholder(&self) -> bool {
+        self.0.as_ref().starts_with(':')
+    }
 }
+
 impl EntryKey<&'static str> {
     /// A placeholder value used for displaying keys which are not valid bibtex.
     pub fn placeholder() -> Self {


### PR DESCRIPTION
Fix two alias-related bugs:

- `autobib edit` (and related code) was returning an 'invalid alias' error with placeholder identifiers
- Also allow deleting legacy aliases